### PR TITLE
fix: 보조 카운터 규칙 모달 글씨 줄바꿈 설정

### DIFF
--- a/src/components/counter/SubCounterRuleModal.tsx
+++ b/src/components/counter/SubCounterRuleModal.tsx
@@ -45,9 +45,9 @@ const SubCounterRuleModal: React.FC<SubCounterRuleModalProps> = ({
     <BaseModal visible={visible} onClose={onClose} title="설정">
       <View className="px-6 py-4">
         {/* 보조 카운터 규칙 설정 */}
-        <View className="flex-row items-center justify-start">
-          <Text className="text-base text-black mr-2">보조 카운터</Text>
-          <View className="flex-row items-center">
+        <View className="flex-row flex-wrap items-center justify-start">
+          <Text className="text-base text-black mr-2 shrink">보조 카운터</Text>
+          <View className="flex-row flex-wrap items-center">
             <View className="w-20 mr-2">
               <TextInputBox
                 label=""
@@ -58,7 +58,7 @@ const SubCounterRuleModal: React.FC<SubCounterRuleModalProps> = ({
                 placeholder="0"
               />
             </View>
-            <Text className="text-base text-black">코마다</Text>
+            <Text className="text-base text-black shrink">코마다</Text>
           </View>
         </View>
 


### PR DESCRIPTION
- 기존 시스템 글자 크기가 클 때 글자가 모달 밖으로 튀어나가는 문제 해결

## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #57 


## 🛠 작업 내용

- 기존 시스템 글자 크기가 클 때 글자가 모달 밖으로 튀어나가는 문제 해결
(글자 크기 최대로 설정했을 때 자동 줄바꿈 되는 것을 확인할 수 있는 스크린샷)
<img width="48%" alt="image" src="https://github.com/user-attachments/assets/4a3368bf-9693-457e-a248-9d1a35812147" />


## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)

- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.