### PR TITLE
fix(project): 프로젝트 하위 카운터를 여러 개 생성할 때 마지막 카운터만 저장되는 현상

### DIFF
--- a/src/hooks/useItemList.ts
+++ b/src/hooks/useItemList.ts
@@ -25,6 +25,7 @@ interface UseItemListReturn {
 
   // 핸들러
   setItems: React.Dispatch<React.SetStateAction<Item[]>>;
+  setProject: React.Dispatch<React.SetStateAction<Project | null>>;
   setIsEditMode: React.Dispatch<React.SetStateAction<boolean>>;
   setModalVisible: React.Dispatch<React.SetStateAction<boolean>>;
   setDeleteModalVisible: React.Dispatch<React.SetStateAction<boolean>>;
@@ -205,6 +206,7 @@ export const useItemList = ({ projectId, headerSetup }: UseItemListProps): UseIt
     pendingItem,
     // 상태 설정 함수들
     setItems,
+    setProject,
     setIsEditMode,
     setModalVisible,
     setDeleteModalVisible,


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #55 


## 🛠 작업 내용

- 프로젝트 카운터를 생성할 때 저장소에서 최신 프로젝트를 읽어 프로젝트 하위 카운터 배열을 업데이트하도록 수정했습니다.

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)

- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.