### PR TITLE
design: 활동기록 텍스트 왼쪽 정렬로 수정

### DIFF
--- a/src/components/counter/SegmentRecordModal.tsx
+++ b/src/components/counter/SegmentRecordModal.tsx
@@ -49,24 +49,26 @@ export const SegmentRecordModal: React.FC<SegmentRecordModalProps> = ({
       >
         {sectionRecords.length > 0 ? (
           <View className="flex-row items-center justify-between">
-            {/* 3개 기록 묶음 - 80% 너비, x축 중앙 정렬 */}
+            {/* 3개 기록 묶음 - 80% 너비, x축 중앙 정렬 / 내부 텍스트는 왼쪽 정렬 */}
             <View className="flex-[0.8] items-center">
-              {sectionRecords.map((record, index) => {
-                // 첫 번째: black, 두 번째: darkgray, 세 번째: mediumgray
-                const textColorClass = index === 0 ? 'text-black' : index === 1 ? 'text-darkgray' : 'text-mediumgray';
-                return (
-                  <View key={index}>
-                    <Text
-                      className={`text-sm font-bold ${textColorClass}`}
-                      numberOfLines={1}
-                      ellipsizeMode="tail"
-                      allowFontScaling={false}
-                    >
-                      {record.time} {getEditContentText(record)}
-                    </Text>
-                  </View>
-                );
-              })}
+              <View className="w-full items-start">
+                {sectionRecords.map((record, index) => {
+                  // 첫 번째: black, 두 번째: darkgray, 세 번째: mediumgray
+                  const textColorClass = index === 0 ? 'text-black' : index === 1 ? 'text-darkgray' : 'text-mediumgray';
+                  return (
+                    <View key={index} className="w-full">
+                      <Text
+                        className={`text-sm font-bold ${textColorClass}`}
+                        numberOfLines={1}
+                        ellipsizeMode="tail"
+                        allowFontScaling={false}
+                      >
+                        {record.time} {getEditContentText(record)}
+                      </Text>
+                    </View>
+                  );
+                })}
+              </View>
             </View>
             {/* 실행 취소 버튼 - 20% 너비 */}
             <View className="flex-[0.2] items-end">


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #106 


## 🛠 작업 내용

- 활동기록 텍스트가 중앙 정렬되어 있었습니다. 영역은 중앙으로 정렬하되, 텍스트 각 줄은 왼쪽 정렬되게 합니다.
- 피그마에서 기획한 디자인과 맞춥니다.

수정전 -> 수정후
<p float="left">
<img width="48%" alt="image" src="https://github.com/user-attachments/assets/b9664efd-095a-4cd8-95a3-847d953e5e39" />
<img width="48%" alt="image" src="https://github.com/user-attachments/assets/e083ea8f-4df2-4350-9f91-2202020546da" />
</p>

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)

- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 시스템 폰트 사이즈, 화면 크기 변화에 대응하는 걸 확인했습니다.