### PR TITLE
refactor: 삭제 모드 사용성 개선

### DIFF
--- a/src/hooks/useMain.ts
+++ b/src/hooks/useMain.ts
@@ -164,8 +164,14 @@ export const useMain = () => {
 
     removeItem(itemToDelete.id);
     resetDeleteModalState();
-    setItems(prev => prev.filter(item => item.id !== itemToDelete.id));
-  }, [itemToDelete, resetDeleteModalState, setItems]);
+
+    const nextItems = items.filter((item) => item.id !== itemToDelete.id);
+    setItems(nextItems);
+    // 삭제 후 목록이 비면 편집할 항목이 없으므로 edit 모드 자동 해제
+    if (nextItems.length === 0) {
+      setIsEditMode(false);
+    }
+  }, [itemToDelete, items, resetDeleteModalState, setItems, setIsEditMode]);
 
   const handleSortSelect = useCallback((_option: string) => {
     // 정렬 설정이 storage에 저장되었으므로, 현재 items를 다시 정렬하여 즉시 반영

--- a/src/hooks/useProjectDetail.ts
+++ b/src/hooks/useProjectDetail.ts
@@ -174,9 +174,14 @@ export const useProjectDetail = () => {
       removeCounterFromProject(project.id, itemToDelete.id);
     }
 
-    setItems(prev => prev.filter(i => i.id !== itemToDelete.id));
+    const nextItems = items.filter((i) => i.id !== itemToDelete.id);
+    setItems(nextItems);
     resetDeleteModalState();
-  }, [itemToDelete, project, setItems, resetDeleteModalState]);
+    // 삭제 후 목록이 비면 편집할 항목이 없으므로 edit 모드 자동 해제
+    if (nextItems.length === 0) {
+      setIsEditMode(false);
+    }
+  }, [itemToDelete, project, items, setItems, resetDeleteModalState, setIsEditMode]);
 
   const handleSortSelect = useCallback((_option: string) => {
     // 정렬 설정이 storage에 저장되었으므로, 현재 items를 다시 정렬하여 즉시 반영


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #112 


## 🛠 작업 내용

- 삭제 후 목록이 비면 편집할 항목이 없으므로 edit모드가 자동 해제되도록 하여 삭제 모드의 사용성을 개선했습니다.

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)

- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 시스템 폰트 사이즈, 화면 크기 변화에 대응하는 걸 확인했습니다.