### PR TITLE
fix: 리뷰 버튼 미동작 오류

### DIFF
--- a/src/components/settings/SettingsLinks.tsx
+++ b/src/components/settings/SettingsLinks.tsx
@@ -1,40 +1,20 @@
 // src/components/settings/SettingsLinks.tsx
 import React from 'react';
 import { View, Linking } from 'react-native';
-import DeviceInfo from 'react-native-device-info';
 import InAppReview from 'react-native-in-app-review';
-import {
-  ONE_STORE_INSTALLER_PACKAGE,
-  ONE_STORE_URL,
-  PLAY_STORE_URL,
-} from '@constants/storeUrls';
+import { PLAY_STORE_URL } from '@constants/storeUrls';
 import IconBox from './IconBox';
-
-/** getInstallerPackageName 대기 최대 시간 (멈춤 방지) */
-const INSTALLER_TIMEOUT_MS = 2500;
 
 interface SettingsLinksProps {}
 
 /**
  * 설정 화면의 외부 링크 버튼들을 묶은 컴포넌트
+ * - 기본: 플레이스토어 기준 (인앱 리뷰 시도 → 실패 시 스토어 링크)
+ * - 원스토어 AAB 빌드 시: handleReviewPress를 아래 주석 블록 코드로 교체 후 빌드
  */
 const SettingsLinks: React.FC<SettingsLinksProps> = () => {
+  // 플레이스토어용: 인앱 리뷰 시도 후, 안 되면 스토어 링크로 폴백
   const handleReviewPress = async () => {
-    const installer = await Promise.race([
-      DeviceInfo.getInstallerPackageName(),
-      new Promise<never>((_, reject) =>
-        setTimeout(() => reject(new Error('installer timeout')), INSTALLER_TIMEOUT_MS)
-      ),
-    ]).catch(() => null);
-
-    const isOneStore = installer === ONE_STORE_INSTALLER_PACKAGE;
-
-    if (isOneStore) {
-      Linking.openURL(ONE_STORE_URL).catch(() => {});
-      return;
-    }
-
-    // 플레이스토어 또는 설치처 미확인: 인앱 리뷰 시도 후, 안 되면 링크로 폴백
     try {
       if (InAppReview.isAvailable()) {
         await InAppReview.RequestInAppReview();
@@ -43,9 +23,17 @@ const SettingsLinks: React.FC<SettingsLinksProps> = () => {
     } catch {
       // In-App Review 실패 시 아래 폴백으로 진행
     }
-
     Linking.openURL(PLAY_STORE_URL).catch(() => {});
   };
+
+  /*
+   * [원스토어 AAB 빌드 시] 위 handleReviewPress 대신 아래를 사용 (링크로만 이동)
+   * storeUrls에서 ONE_STORE_URL import 추가 후:
+   *
+   * const handleReviewPress = () => {
+   *   Linking.openURL(ONE_STORE_URL).catch(() => {});
+   * };
+   */
 
   const handleContactPress = () => {
     const subject = encodeURIComponent('어쩜! 단수 카운터 문의');


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #111 


## 🛠 작업 내용

- 플레이스토어에서 다운받은 앱의 경우 리뷰 버튼을 누르면 인 앱 리뷰가 나오도록 설정했었습니다. 이후 원스토어/플레이스토어 리뷰 로직 분리 과정에서 문제가 발생했고, 이를 인지하지 못한 채 1.3.0으로 배포했습니다.
- 다운로드 정보에서 원스토어/플레이스토어를 확인하고 분기하는 코드가 문제라고 생각되어 이를 삭제했습니다. 현재 usb디버깅이 불가능하여 릴리즈 버전의 로그 확인이 안되어 이렇게 임시로 조치했습니다. 해결될 때까지 원스토어/플레이스토어 업로드 aab파일을 달리 하여 추출해 업로드합니다. 

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)

- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 시스템 폰트 사이즈, 화면 크기 변화에 대응하는 걸 확인했습니다.