### PR TITLE
feat: 하위 카운터의 카운터명 수정

### DIFF
--- a/src/hooks/useItemInfo.ts
+++ b/src/hooks/useItemInfo.ts
@@ -22,6 +22,7 @@ export const useItemInfo = () => {
   const [needle, setNeedle] = useState('');
   const [notes, setNotes] = useState('');
   const [isRootLevelItem, setIsRootLevelItem] = useState(false);
+  const [itemType, setItemType] = useState<'project' | 'counter'>('counter');
 
   // 초기값 저장 (변경사항 비교용)
   const initialValuesRef = useRef({
@@ -53,6 +54,7 @@ export const useItemInfo = () => {
       return;
     }
 
+    setItemType(item.type);
     setIsRootLevelItem(item.type === 'project' || (item.type === 'counter' && !item.parentProjectId));
 
     // 네비게이션 타이틀 설정
@@ -258,6 +260,7 @@ export const useItemInfo = () => {
     notes,
     setNotes,
     isRootLevelItem,
+    itemType,
     // 모달 상태
     showSaveConfirmModal,
     showTitleErrorModal,

--- a/src/hooks/useItemInfo.ts
+++ b/src/hooks/useItemInfo.ts
@@ -21,6 +21,7 @@ export const useItemInfo = () => {
   const [yarn, setYarn] = useState('');
   const [needle, setNeedle] = useState('');
   const [notes, setNotes] = useState('');
+  const [isRootLevelItem, setIsRootLevelItem] = useState(false);
 
   // 초기값 저장 (변경사항 비교용)
   const initialValuesRef = useRef({
@@ -51,6 +52,8 @@ export const useItemInfo = () => {
     if (!item) {
       return;
     }
+
+    setIsRootLevelItem(item.type === 'project' || (item.type === 'counter' && !item.parentProjectId));
 
     // 네비게이션 타이틀 설정
     navigation.setOptions({ title: `"${item.title}" 정보` });
@@ -254,6 +257,7 @@ export const useItemInfo = () => {
     setNeedle,
     notes,
     setNotes,
+    isRootLevelItem,
     // 모달 상태
     showSaveConfirmModal,
     showTitleErrorModal,

--- a/src/navigation/HeaderOptions.tsx
+++ b/src/navigation/HeaderOptions.tsx
@@ -83,7 +83,7 @@ export const getHeaderRightWithActivateInfoSettings = (
   timerIsActive: boolean,
   onTimerPress: () => void,
   counterId: string,
-  onInfoPress?: () => void
+  onInfoPress: () => void
 ): React.JSX.Element => {
   return (
     <View className="flex-row items-center">
@@ -101,12 +101,10 @@ export const getHeaderRightWithActivateInfoSettings = (
         />
       </View>
 
-      {/* Info 버튼 (선택적) */}
-      {onInfoPress && (
-        <TouchableOpacity onPress={onInfoPress} style={{ marginRight: 12 }}>
-          <Info size={26} color="black" />
-        </TouchableOpacity>
-      )}
+      {/* Info 버튼 */}
+      <TouchableOpacity onPress={onInfoPress} style={{ marginRight: 12 }}>
+        <Info size={26} color="black" />
+      </TouchableOpacity>
 
       {/* 설정 */}
       <TouchableOpacity onPress={() => navigation.navigate('Setting')} style={{ marginRight: 4 }}>

--- a/src/screens/CounterDetail.tsx
+++ b/src/screens/CounterDetail.tsx
@@ -127,7 +127,6 @@ const CounterDetail = () => {
   // 방향 이미지 크기 계산 (원본 비율 90 / 189 유지)
   const imageWidth = iconSize * 1.4;
   const imageHeight = iconSize * (90 / 189) * 1.4;
-  const hasParent = !!counter?.parentProjectId;
   const handleLayout = useCallback((event: LayoutChangeEvent) => {
     const { height: nextHeight, width: nextWidth } = event.nativeEvent.layout;
     setLayoutHeight((prev) => (prev !== nextHeight ? nextHeight : prev));
@@ -204,7 +203,7 @@ const CounterDetail = () => {
           () => navigation.navigate('InfoScreen', { itemId: counter.id })
         ),
     });
-  }, [navigation, counter, mascotIsActive, screenSize, resolvedWidth, toggleMascotIsActive, toggleTimerIsActive, hasParent]);
+  }, [navigation, counter, mascotIsActive, screenSize, resolvedWidth, toggleMascotIsActive, toggleTimerIsActive]);
 
 
   // 카운터 데이터가 없으면 렌더링하지 않음
@@ -247,7 +246,7 @@ const CounterDetail = () => {
           <Tooltip
             text="길게 눌러 어쩌미 알림 단 설정하기"
             containerClassName="absolute right-3 top-2 z-50"
-            targetAnchorX={hasParent ? resolvedWidth - 65 : resolvedWidth - 103}
+            targetAnchorX={resolvedWidth - 106}
           />
         )}
 

--- a/src/screens/CounterDetail.tsx
+++ b/src/screens/CounterDetail.tsx
@@ -201,7 +201,7 @@ const CounterDetail = () => {
           counter.timerIsActive,
           toggleTimerIsActive,
           counter.id,
-          hasParent ? undefined : () => navigation.navigate('InfoScreen', { itemId: counter.id })
+          () => navigation.navigate('InfoScreen', { itemId: counter.id })
         ),
     });
   }, [navigation, counter, mascotIsActive, screenSize, resolvedWidth, toggleMascotIsActive, toggleTimerIsActive, hasParent]);

--- a/src/screens/InfoScreen.tsx
+++ b/src/screens/InfoScreen.tsx
@@ -34,6 +34,7 @@ const InfoScreen = () => {
     notes,
     setNotes,
     isRootLevelItem,
+    itemType,
     // 모달 상태
     showSaveConfirmModal,
     showTitleErrorModal,
@@ -52,6 +53,7 @@ const InfoScreen = () => {
   const startDateInputRef = useRef<TextInputBoxRef>(null);
   const endDateInputRef = useRef<TextInputBoxRef>(null);
   const gaugeInputRef = useRef<TextInputBoxRef>(null);
+  const titleFieldText = itemType === 'counter' ? '카운터명' : '프로젝트명';
 
   return (
     <SafeAreaView style={screenStyles.flex1} edges={safeAreaEdges}>
@@ -64,10 +66,10 @@ const InfoScreen = () => {
           {/* 제목 입력 필드 */}
           <TextInputBox
             ref={titleInputRef}
-            label="이름"
+            label={titleFieldText}
             value={title}
             onChangeText={setTitle}
-            placeholder="프로젝트명 혹은 카운터명"
+            placeholder={titleFieldText}
             type="text"
             required
             returnKeyType={isRootLevelItem ? 'next' : 'done'}

--- a/src/screens/InfoScreen.tsx
+++ b/src/screens/InfoScreen.tsx
@@ -33,6 +33,7 @@ const InfoScreen = () => {
     setNeedle,
     notes,
     setNotes,
+    isRootLevelItem,
     // 모달 상태
     showSaveConfirmModal,
     showTitleErrorModal,
@@ -69,77 +70,83 @@ const InfoScreen = () => {
             placeholder="프로젝트명 혹은 카운터명"
             type="text"
             required
-            returnKeyType="next"
-            onSubmitEditing={() => startDateInputRef.current?.focus()}
-            blurOnSubmit={false}
+            returnKeyType={isRootLevelItem ? 'next' : 'done'}
+            onSubmitEditing={
+              isRootLevelItem ? () => startDateInputRef.current?.focus() : undefined
+            }
+            blurOnSubmit={!isRootLevelItem}
           />
 
-          {/* 날짜 입력 필드들 (좌우 배치) */}
-          <View className="flex-row justify-between">
-            <View className="flex-1 mr-2">
+          {isRootLevelItem && (
+            <>
+              {/* 날짜 입력 필드들 (좌우 배치) */}
+              <View className="flex-row justify-between">
+                <View className="flex-1 mr-2">
+                  <TextInputBox
+                    ref={startDateInputRef}
+                    label="시작일"
+                    value={startDate}
+                    onChangeText={setStartDate}
+                    placeholder="yyyy.mm.dd"
+                    type="date"
+                    returnKeyType="next"
+                    onSubmitEditing={() => endDateInputRef.current?.focus()}
+                    blurOnSubmit={false}
+                  />
+                </View>
+                <View className="flex-1 ml-2">
+                  <TextInputBox
+                    ref={endDateInputRef}
+                    label="종료일"
+                    value={endDate}
+                    onChangeText={setEndDate}
+                    placeholder="yyyy.mm.dd"
+                    type="date"
+                    returnKeyType="next"
+                    onSubmitEditing={() => gaugeInputRef.current?.focus()}
+                    blurOnSubmit={false}
+                  />
+                </View>
+              </View>
+
+              {/* 게이지 입력 필드 */}
               <TextInputBox
-                ref={startDateInputRef}
-                label="시작일"
-                value={startDate}
-                onChangeText={setStartDate}
-                placeholder="yyyy.mm.dd"
-                type="date"
-                returnKeyType="next"
-                onSubmitEditing={() => endDateInputRef.current?.focus()}
-                blurOnSubmit={false}
+                ref={gaugeInputRef}
+                label="게이지"
+                value={gauge}
+                onChangeText={setGauge}
+                placeholder="게이지"
+                type="longText"
               />
-            </View>
-            <View className="flex-1 ml-2">
+
+              {/* 실 정보 입력 필드 */}
               <TextInputBox
-                ref={endDateInputRef}
-                label="종료일"
-                value={endDate}
-                onChangeText={setEndDate}
-                placeholder="yyyy.mm.dd"
-                type="date"
-                returnKeyType="next"
-                onSubmitEditing={() => gaugeInputRef.current?.focus()}
-                blurOnSubmit={false}
+                label="실"
+                value={yarn}
+                onChangeText={setYarn}
+                placeholder="사용한 실"
+                type="longText"
               />
-            </View>
-          </View>
 
-          {/* 게이지 입력 필드 */}
-          <TextInputBox
-            ref={gaugeInputRef}
-            label="게이지"
-            value={gauge}
-            onChangeText={setGauge}
-            placeholder="게이지"
-            type="longText"
-          />
+              {/* 바늘 정보 입력 필드 */}
+              <TextInputBox
+                label="바늘"
+                value={needle}
+                onChangeText={setNeedle}
+                placeholder="사용한 바늘"
+                type="longText"
+              />
 
-          {/* 실 정보 입력 필드 */}
-          <TextInputBox
-            label="실"
-            value={yarn}
-            onChangeText={setYarn}
-            placeholder="사용한 실"
-            type="longText"
-          />
-
-          {/* 바늘 정보 입력 필드 */}
-          <TextInputBox
-            label="바늘"
-            value={needle}
-            onChangeText={setNeedle}
-            placeholder="사용한 바늘"
-            type="longText"
-          />
-
-          {/* 기타 메모 입력 필드 */}
-          <TextInputBox
-            label="기타"
-            value={notes}
-            onChangeText={setNotes}
-            placeholder="기타 정보"
-            type="longText"
-          />
+              {/* 기타 메모 입력 필드 */}
+              <TextInputBox
+                label="기타"
+                value={notes}
+                onChangeText={setNotes}
+                placeholder="기타 정보"
+                type="longText"
+              />
+            </>
+          )}
 
           {/* 하단 액션 버튼들 */}
           <View className="flex-row justify-evenly mt-2">


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #137 


## 🛠 작업 내용

- 상세 구현 배경은 이슈에 작성했습니다.
- 어떤 계층의 카운터도 헤더에 항상 ⓘ버튼이 표시되게 했습니다. 일관된 사용자 경험에도 도움이 됩니다.
- 하위 카운터의 경우 info 페이지에서 이름만 변경할 수 있도록 분기 처리를 했습니다.
- 카운터 헤더 구성이 다름에 따라 존재하던 tooltip 분기를 제거했습니다.
- info 페이지의 "이름" label이 사용자에게 불명확할 것 같아, "카운터명" 혹은 "프로젝트명"이 표시되도록 수정했습니다.

좌 : 최상위 계층 카운터
우 : 프로젝트 하위 카운터
<p float="left">
<img width="48%" alt="image" src="https://github.com/user-attachments/assets/e9a007d3-a69b-4e0a-9a16-565b6dd57eaf" />
<img width="48%" alt="image" src="https://github.com/user-attachments/assets/afd72991-f352-4c85-bcf6-6a87b0be9d10" />
</p>

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)

- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 시스템 폰트 사이즈, 화면 크기 변화에 대응하는 걸 확인했습니다.
- [x] 동료 작업자에게 수정 사항을 공유했습니다. 