### PR TITLE
feat: 서브 슬라이드 모달 on/off 전역 상태 추가 및 화면 연동

### DIFF
--- a/src/navigation/HeaderOptions.tsx
+++ b/src/navigation/HeaderOptions.tsx
@@ -3,7 +3,7 @@ import { ChevronLeft, Settings, Trash2, Info, ArrowDownUp, Timer, Mic } from 'lu
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from './AppNavigator';
 
-import { View, TouchableOpacity } from 'react-native';
+import { View, TouchableOpacity, Text } from 'react-native';
 import ActivateToggle from '@components/common/ActivateToggle';
 
 export const getDefaultHeaderLeft = (
@@ -84,6 +84,8 @@ export const getHeaderRightWithActivateInfoSettings = (
   onTimerPress: () => void,
   voiceCommandsEnabled: boolean,
   onVoicePress: () => void,
+  subSlideModalsEnabled: boolean,
+  onSubSlideModalsPress: () => void,
   counterId: string,
   onInfoPress: () => void
 ): React.JSX.Element => {
@@ -99,6 +101,23 @@ export const getHeaderRightWithActivateInfoSettings = (
         accessibilityHint="탭하여 음성 인식 단수 증감 기능을 켜거나 끕니다"
       >
         <Mic size={24} color={voiceCommandsEnabled ? 'black' : '#B8B8B8'} />
+      </TouchableOpacity>
+      <TouchableOpacity
+        onPress={onSubSlideModalsPress}
+        className="mr-2"
+        accessible={true}
+        accessibilityRole="button"
+        accessibilityLabel="서브 슬라이드 모달"
+        accessibilityHint="탭하여 활동기록 및 보조 카운터 슬라이드 모달 표시를 켜거나 끕니다"
+        accessibilityState={{ selected: subSlideModalsEnabled }}
+      >
+        <Text
+          allowFontScaling={false}
+          className="text-base font-bold"
+          style={{ color: subSlideModalsEnabled ? 'black' : '#B8B8B8' }}
+        >
+          sub
+        </Text>
       </TouchableOpacity>
       <View
         pointerEvents="none"

--- a/src/screens/CounterDetail.tsx
+++ b/src/screens/CounterDetail.tsx
@@ -1,6 +1,6 @@
 // src/screens/CounterDetail.tsx
 
-import { useLayoutEffect, useCallback, useState, useRef } from 'react';
+import { useLayoutEffect, useCallback, useState, useRef, useEffect } from 'react';
 import { View, Text, useWindowDimensions, Animated, LayoutChangeEvent, Platform } from 'react-native';
 import { SafeAreaView, useSafeAreaInsets, Edge } from 'react-native-safe-area-context';
 import { useNavigation, useRoute, useFocusEffect } from '@react-navigation/native';
@@ -14,7 +14,12 @@ import { CounterTouchArea, CounterDirection, CounterActions, CounterModals, SubC
 import Tooltip from '@components/common/Tooltip';
 import { ADD_KEY_CODES, SUBTRACT_KEY_CODES } from '@constants/hardwareKeyCodes';
 import { getScreenSize, getIconSize, getProgressBarHeightPx, getTextClass, ScreenSize } from '@constants/screenSizeConfig';
-import { getTooltipEnabledSetting } from '@storage/settings';
+import {
+  getTooltipEnabledSetting,
+  getSubSlideModalsEnabledSetting,
+  setSubSlideModalsEnabledSetting,
+  subscribeSubSlideModalsEnabledSettingChange,
+} from '@storage/settings';
 import { screenStyles } from '@styles/screenStyles';
 import { useCounter } from '@hooks/useCounter';
 import { useVoiceCommands } from '@hooks/useVoiceCommands';
@@ -132,6 +137,9 @@ const CounterDetail = () => {
   } = useCounter({ counterId });
 
   const [tooltipEnabled, setTooltipEnabled] = useState(true);
+  const [subSlideModalsEnabled, setSubSlideModalsEnabled] = useState(
+    () => getSubSlideModalsEnabledSetting()
+  );
   const [voiceRecognitionError, setVoiceRecognitionError] = useState<string>('');
   const {
     isVoiceCommandsEnabled,
@@ -277,6 +285,22 @@ const CounterDetail = () => {
     }, [])
   );
 
+  useEffect(() => {
+    const syncSubSlideModalsEnabled = () => {
+      setSubSlideModalsEnabled(getSubSlideModalsEnabledSetting());
+    };
+
+    syncSubSlideModalsEnabled();
+
+    return subscribeSubSlideModalsEnabledSettingChange(syncSubSlideModalsEnabled);
+  }, []);
+
+  const toggleSubSlideModalsEnabled = useCallback(() => {
+    const nextValue = !subSlideModalsEnabled;
+    setSubSlideModalsEnabledSetting(nextValue);
+    setSubSlideModalsEnabled(nextValue);
+  }, [subSlideModalsEnabled]);
+
   useFocusEffect(
     useCallback(() => {
       if (Platform.OS !== 'android') {
@@ -337,6 +361,8 @@ const CounterDetail = () => {
           toggleTimerIsActive,
           isVoiceCommandsEnabled,
           toggleVoiceCommands,
+          subSlideModalsEnabled,
+          toggleSubSlideModalsEnabled,
           counter.id,
           () => navigation.navigate('InfoScreen', { itemId: counter.id })
         ),
@@ -347,7 +373,9 @@ const CounterDetail = () => {
     isVoiceCommandsEnabled,
     mascotIsActive,
     screenSize,
+    subSlideModalsEnabled,
     toggleMascotIsActive,
+    toggleSubSlideModalsEnabled,
     toggleTimerIsActive,
     toggleVoiceCommands,
   ]);
@@ -496,7 +524,7 @@ const CounterDetail = () => {
       </Animated.View>
 
       {/* 구간 기록 모달 - LARGE 화면에서만 표시 */}
-      {screenSize === ScreenSize.LARGE && (
+      {screenSize === ScreenSize.LARGE && subSlideModalsEnabled && (
         <SegmentRecordModal
           isOpen={counter.sectionModalIsOpen ?? false}
           onToggle={handleSectionModalToggle}
@@ -510,26 +538,28 @@ const CounterDetail = () => {
       )}
 
       {/* 보조 카운터 모달 */}
-      <SubCounterModal
-        isOpen={subModalIsOpen}
-        onToggle={handleSubModalToggle}
-        onAdd={runHighlightedSubAdd}
-        onSubtract={runHighlightedSubSubtract}
-        showVoiceCommandHints={effectiveVoiceCommandsActive}
-        highlightedAction={subTouchAreaHighlight}
-        inputDisabled={isInputBlocked}
-        onReset={handleSubReset}
-        onEdit={handleSubEdit}
-        onRule={handleSubRule}
-        handleWidth={subModalHandleWidth}
-        subCount={subCount}
-        subRule={subRule}
-        subRuleIsActive={subRuleIsActive}
-        screenSize={screenSize}
-        width={subModalWidth}
-        height={subModalHeight}
-        centerY={subModalCenterY}
-      />
+      {subSlideModalsEnabled && (
+        <SubCounterModal
+          isOpen={subModalIsOpen}
+          onToggle={handleSubModalToggle}
+          onAdd={runHighlightedSubAdd}
+          onSubtract={runHighlightedSubSubtract}
+          showVoiceCommandHints={effectiveVoiceCommandsActive}
+          highlightedAction={subTouchAreaHighlight}
+          inputDisabled={isInputBlocked}
+          onReset={handleSubReset}
+          onEdit={handleSubEdit}
+          onRule={handleSubRule}
+          handleWidth={subModalHandleWidth}
+          subCount={subCount}
+          subRule={subRule}
+          subRuleIsActive={subRuleIsActive}
+          screenSize={screenSize}
+          width={subModalWidth}
+          height={subModalHeight}
+          centerY={subModalCenterY}
+        />
+      )}
 
       {/* 모달들 */}
       <CounterModals

--- a/src/storage/settings.ts
+++ b/src/storage/settings.ts
@@ -16,6 +16,7 @@ const KEY_AUTO_PLAY_ELAPSED_TIME = 'settings.autoPlayElapsedTime';
 const KEY_TOOLTIP_ENABLED = 'settings.tooltipEnabled';
 const KEY_SHOW_ELAPSED_TIME_IN_LIST = 'settings.showElapsedTimeInList';
 const KEY_VOICE_COMMANDS_ENABLED = 'settings.voiceCommandsEnabled';
+const KEY_SUB_SLIDE_MODALS_ENABLED = 'settings.subSlideModalsEnabled';
 const KEY_VOICE_RECOGNITION_PERMISSION_STATUS =
   'settings.voiceRecognitionPermissionStatus';
 
@@ -30,6 +31,7 @@ const DEFAULT_AUTO_PLAY_ELAPSED_TIME = true;
 const DEFAULT_TOOLTIP_ENABLED = true;
 const DEFAULT_SHOW_ELAPSED_TIME_IN_LIST = false;
 const DEFAULT_VOICE_COMMANDS_ENABLED = false;
+const DEFAULT_SUB_SLIDE_MODALS_ENABLED = true;
 
 export type VoiceRecognitionPermissionStatus =
   | 'undetermined'
@@ -221,6 +223,41 @@ export const setVoiceCommandsEnabledSetting = (value: boolean) => {
 export const getVoiceCommandsEnabledSetting = (): boolean => {
   const value = storage.getString(KEY_VOICE_COMMANDS_ENABLED);
   return value ? JSON.parse(value) : DEFAULT_VOICE_COMMANDS_ENABLED;
+};
+
+/**
+ * CounterDetail의 슬라이드 모달 표시 설정을 저장합니다.
+ * @param value 슬라이드 모달 표시 여부
+ */
+export const setSubSlideModalsEnabledSetting = (value: boolean) => {
+  storage.set(KEY_SUB_SLIDE_MODALS_ENABLED, JSON.stringify(value));
+};
+
+/**
+ * CounterDetail의 슬라이드 모달 표시 설정을 가져옵니다.
+ * @returns 슬라이드 모달 표시 여부 (기본값: true)
+ */
+export const getSubSlideModalsEnabledSetting = (): boolean => {
+  const value = storage.getString(KEY_SUB_SLIDE_MODALS_ENABLED);
+  return value ? JSON.parse(value) : DEFAULT_SUB_SLIDE_MODALS_ENABLED;
+};
+
+/**
+ * 슬라이드 모달 표시 설정 변경을 구독합니다.
+ * @returns unsubscribe 함수
+ */
+export const subscribeSubSlideModalsEnabledSettingChange = (
+  callback: () => void
+) => {
+  const listener = storage.addOnValueChangedListener((changedKey) => {
+    if (changedKey === KEY_SUB_SLIDE_MODALS_ENABLED) {
+      callback();
+    }
+  });
+
+  return () => {
+    listener.remove();
+  };
 };
 
 /**


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #87 


## 🛠 작업 내용
<p float="left">
<img width="48%" alt="image" src="https://github.com/user-attachments/assets/007e24e3-f4fa-41cb-83cc-d536618ef56f" />
<img width="48%" alt="image" src="https://github.com/user-attachments/assets/68c25056-7ada-4731-9a6e-6cdf2c6d726f" />
</p>

- 전역으로 적용되는 슬라이드 모달 on/off 설정을 추가했습니다.
- 카운터 헤더의 'sub'버튼을 사용해 동작합니다.

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)

- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 시스템 폰트 사이즈, 화면 크기 변화에 대응하는 걸 확인했습니다.
- [x] 동료 작업자에게 수정 사항을 공유했습니다. 