### PR TITLE
refactor: 색상 스와치 교체

### DIFF
--- a/src/components/counter/ColorPicker.tsx
+++ b/src/components/counter/ColorPicker.tsx
@@ -3,9 +3,11 @@ import React, { useState } from 'react';
 import { Pressable, View } from 'react-native';
 import ColorPickerIcon from '@assets/images/color_picker.svg';
 import ColorPicker, { Panel1, Swatches, HueSlider } from 'reanimated-color-picker';
-import { RED_ORANGE_SWATCHES } from '@constants/colors';
+import { RULE_SWATCH_COLORS } from '@constants/colors';
 import RoundedButton from '@components/common/RoundedButton';
 import BaseModal from '@components/common/modals/BaseModal/BaseModal';
+
+const SWATCH_ROW_SIZE = 5;
 
 interface ColorPickerProps {
   selectedColor: string; // hex 색상 값 (예: '#fc3e39', 필수)
@@ -77,11 +79,11 @@ const ColorPickerComponent: React.FC<ColorPickerProps> = ({
             <HueSlider />
             <View className="h-4" />{/* 슬라이더 ↔ 스와치 간격 */}
             <View>
-              {/* 스와치 1행 (인덱스 0, 2, 3, 4, 5) */}
-              <Swatches colors={[0, 2, 3, 4, 5].map((i) => RED_ORANGE_SWATCHES[i]).filter(Boolean)} />
+              {/* 스와치 1행 (인덱스 0~4) */}
+              <Swatches colors={RULE_SWATCH_COLORS.slice(0, SWATCH_ROW_SIZE)} />
               <View className="h-2" />{/* 스와치 행 간격 */}
-              {/* 스와치 2행 (인덱스 6~10) */}
-              <Swatches colors={RED_ORANGE_SWATCHES.slice(6, 11).filter(Boolean)} />
+              {/* 스와치 2행 (인덱스 5~9) */}
+              <Swatches colors={RULE_SWATCH_COLORS.slice(SWATCH_ROW_SIZE, SWATCH_ROW_SIZE * 2)} />
             </View>
           </ColorPicker>
           <View className="mt-4 flex-row justify-evenly">{/* 컨텐츠 ↔ 버튼 영역 간격 */}

--- a/src/constants/colors.d.ts
+++ b/src/constants/colors.d.ts
@@ -1,5 +1,8 @@
 /** red-orange 팔레트 (tailwind theme용) */
 export const RED_ORANGE_PALETTE: Record<string, string>;
 
-/** ColorPicker Swatches용 배열 */
+/** red-orange 팔레트 기반 배열 */
 export const RED_ORANGE_SWATCHES: string[];
+
+/** 규칙 카드와 ColorPicker 스와치 전용 색상 */
+export const RULE_SWATCH_COLORS: string[];

--- a/src/constants/colors.js
+++ b/src/constants/colors.js
@@ -1,6 +1,6 @@
 /**
  * red-orange 팔레트
- * tailwind.config.js와 ColorPicker Swatches에서 공유
+ * tailwind.config.js에서 사용하는 테마 색상
  */
 
 const RED_ORANGE_PALETTE = {
@@ -17,10 +17,25 @@ const RED_ORANGE_PALETTE = {
   '950': '#490806',
 };
 
-/** ColorPicker Swatches용 배열 (50 ~ 950 순서) */
+/** red-orange 팔레트 기반 배열 (50 ~ 950 순서) */
 const RED_ORANGE_SWATCHES = Object.values(RED_ORANGE_PALETTE);
+
+/** 규칙 카드와 ColorPicker 스와치 전용 색상 */
+const RULE_SWATCH_COLORS = [
+  '#EF5777',
+  '#574559',
+  '#04BFAD',
+  '#F2A922',
+  '#D9B391',
+  '#A9CBD9',
+  '#D4E157',
+  '#DAC6E8',
+  '#FFA685',
+  '#BF2424',
+];
 
 module.exports = {
   RED_ORANGE_PALETTE,
   RED_ORANGE_SWATCHES,
+  RULE_SWATCH_COLORS,
 };

--- a/src/utils/ruleUtils.ts
+++ b/src/utils/ruleUtils.ts
@@ -1,5 +1,5 @@
 import { RepeatRule, RuleEndMode } from '@storage/types';
-import { RED_ORANGE_SWATCHES } from '@constants/colors';
+import { RULE_SWATCH_COLORS } from '@constants/colors';
 
 const resolveRuleEndMode = (
   endNumber: number,
@@ -263,25 +263,20 @@ export const calculateRulePreviewSummary = (
   };
 };
 
-/** 색상 우선순위: 2단계씩 건너뛰며 (1,3,5,7,9,11 → 2, 4,6,8,10) */
-// 100번 컬러(index 1)는 배경색과 동일하여 제거
-const COLOR_PRIORITY_INDICES = [0, 2, 4, 6, 8, 10, 3, 5, 7, 9];
-
 /**
  * 신규 규칙 카드의 기본 색상 반환
- * 기존 규칙과 겹치지 않는 red-orange 색상을 우선순위에 따라 선택, 모두 사용 중이면 첫 번째 색상 반환
+ * 기존 규칙과 겹치지 않는 스와치 색상을 순서대로 선택하고, 모두 사용 중이면 첫 번째 색상부터 순환
  */
 export const getDefaultColorForNewRule = (existingRules: RepeatRule[]): string => {
   const usedColors = new Set(existingRules.map((r) => r.color));
-  const available = COLOR_PRIORITY_INDICES.find(
-    (i) => RED_ORANGE_SWATCHES[i] && !usedColors.has(RED_ORANGE_SWATCHES[i])
-  );
-  if (available !== undefined) {
-    return RED_ORANGE_SWATCHES[available];
+  const available = RULE_SWATCH_COLORS.find((color) => !usedColors.has(color));
+
+  if (available) {
+    return available;
   }
-  // 모두 사용 중이면 우선순위 순서대로 순환
-  const cycleIndex = existingRules.length % COLOR_PRIORITY_INDICES.length;
-  return RED_ORANGE_SWATCHES[COLOR_PRIORITY_INDICES[cycleIndex]];
+
+  const cycleIndex = existingRules.length % RULE_SWATCH_COLORS.length;
+  return RULE_SWATCH_COLORS[cycleIndex];
 };
 
 /** hex 색상이 진하면 true (텍스트 흰색 권장) */


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #147 


## 🛠 작업 내용

- 알림 규칙 설정에서 사용되는 색상 스와치 10개를 다른 색으로 교체하였음
- 기존에는 red orange컬러로 알림 규칙을 생성할 때 2단계씩 뛰어 생성하였으나, 색이 달라짐에 따라 단계별로 순차적으로 생성하도록 하였음.+

<p float="left">
<img width="48%" alt="image" src="https://github.com/user-attachments/assets/3c3217e8-eb4b-4607-aa7c-8b858b050d68" />
<img width="48%" alt="image" src="https://github.com/user-attachments/assets/8024bdcc-a23a-4756-9296-6564c9b04b03" />
</p>

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)

- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 시스템 폰트 사이즈, 화면 크기 변화에 대응하는 걸 확인했습니다.
- [x] 동료 작업자에게 수정 사항을 공유했습니다. 