### PR TITLE
refactor: 설정 페이지 섹션 분리 가독성 향상 및 신규 링크 이동 버튼 추가

### DIFF
--- a/src/components/settings/SettingsCheckBoxes.tsx
+++ b/src/components/settings/SettingsCheckBoxes.tsx
@@ -1,6 +1,6 @@
 // src/components/settings/SettingsCheckBoxes.tsx
 import React, { useEffect, useState, useCallback } from 'react';
-import { View } from 'react-native';
+import { View, Text } from 'react-native';
 import { CommonActions, useNavigation } from '@react-navigation/native';
 
 import CheckBox from '@components/common/CheckBox';
@@ -21,6 +21,46 @@ import {
 
 interface SettingsCheckBoxesProps {}
 
+interface SettingsItem {
+  label: string;
+  checked: boolean;
+  onToggle: () => void;
+}
+
+interface SettingsSectionProps {
+  title: string;
+  items: SettingsItem[];
+  titleClassName?: string;
+}
+
+const SettingsSection: React.FC<SettingsSectionProps> = ({
+  title,
+  items,
+  titleClassName = 'text-darkgray',
+}) => {
+  return (
+    <View className="mb-6">
+      <View className="mb-2 flex-row items-center px-4">
+        <Text className={`mr-3 text-sm font-semibold ${titleClassName}`}>
+          {title}
+        </Text>
+        <View className="flex-1 border-b border-lightgray" />
+      </View>
+      <View>
+        {items.map((item) => (
+          <View key={item.label}>
+            <CheckBox
+              label={item.label}
+              checked={item.checked}
+              onToggle={item.onToggle}
+            />
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+};
+
 /**
  * 설정 화면의 체크박스들을 묶은 컴포넌트
  */
@@ -34,7 +74,6 @@ const SettingsCheckBoxes: React.FC<SettingsCheckBoxesProps> = () => {
   const [screenAwake, setScreenAwake] = useState(true);
   const [tooltipEnabled, setTooltipEnabled] = useState(true);
   const [autoPlayElapsedTime, setAutoPlayElapsedTime] = useState(true);
-  const [resetConfirm, setResetConfirm] = useState(false);
   const [resetModalVisible, setResetModalVisible] = useState(false);
   const [errorModalVisible, setErrorModalVisible] = useState(false);
   const [errorMessage, setErrorMessage] = useState('');
@@ -116,7 +155,6 @@ const SettingsCheckBoxes: React.FC<SettingsCheckBoxesProps> = () => {
       clearAllProjectData();
 
       // 상태 초기화
-      setResetConfirm(false);
       setResetModalVisible(false);
 
       // 앱을 Main 화면으로 재시작
@@ -136,41 +174,56 @@ const SettingsCheckBoxes: React.FC<SettingsCheckBoxesProps> = () => {
    */
   const handleResetModalClose = () => {
     setResetModalVisible(false);
-    setResetConfirm(false);
   };
+
+  const deviceSettings: SettingsItem[] = [
+    {
+      label: '스크린 항상 켜두기',
+      checked: screenAwake,
+      onToggle: handleScreenAwakeToggle,
+    },
+    {
+      label: '소리',
+      checked: sound,
+      onToggle: handleSoundToggle,
+    },
+    {
+      label: '진동',
+      checked: vibration,
+      onToggle: handleVibrationToggle,
+    },
+  ];
+
+  const counterSettings: SettingsItem[] = [
+    {
+      label: '툴팁 표시하기',
+      checked: tooltipEnabled,
+      onToggle: handleTooltipToggle,
+    },
+    {
+      label: '타이머 자동 재생',
+      checked: autoPlayElapsedTime,
+      onToggle: handleAutoPlayElapsedTimeToggle,
+    },
+  ];
+
+  const dangerSettings: SettingsItem[] = [
+    {
+      label: '초기화하기',
+      checked: false,
+      onToggle: handleResetToggle,
+    },
+  ];
 
   return (
     <>
-      <View className="mb-6 space-y-4">
-        <CheckBox
-          label="소리"
-          checked={sound}
-          onToggle={handleSoundToggle}
-        />
-        <CheckBox
-          label="진동"
-          checked={vibration}
-          onToggle={handleVibrationToggle}
-        />
-        <CheckBox
-          label="스크린 항상 켜두기"
-          checked={screenAwake}
-          onToggle={handleScreenAwakeToggle}
-        />
-        <CheckBox
-          label="툴팁 표시하기"
-          checked={tooltipEnabled}
-          onToggle={handleTooltipToggle}
-        />
-        <CheckBox
-          label="타이머 자동 재생"
-          checked={autoPlayElapsedTime}
-          onToggle={handleAutoPlayElapsedTimeToggle}
-        />
-        <CheckBox
-          label="초기화하기"
-          checked={resetConfirm}
-          onToggle={handleResetToggle}
+      <View className="mb-6">
+        <SettingsSection title="기기 설정" items={deviceSettings} />
+        <SettingsSection title="카운터 설정" items={counterSettings} />
+        <SettingsSection
+          title="데이터 관리"
+          items={dangerSettings}
+          titleClassName="text-red-orange-500"
         />
       </View>
 

--- a/src/components/settings/SettingsLinks.tsx
+++ b/src/components/settings/SettingsLinks.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { View, Linking } from 'react-native';
 import InAppReview from 'react-native-in-app-review';
-import { PLAY_STORE_URL } from '@constants/storeUrls';
+import { PLAY_STORE_URL, RELEASE_NOTES_URL } from '@constants/storeUrls';
 import IconBox from './IconBox';
 
 interface SettingsLinksProps {}
@@ -13,6 +13,10 @@ interface SettingsLinksProps {}
  * - 원스토어 AAB 빌드 시: handleReviewPress를 아래 주석 블록 코드로 교체 후 빌드
  */
 const SettingsLinks: React.FC<SettingsLinksProps> = () => {
+  const openExternalLink = (url: string) => {
+    Linking.openURL(url).catch(() => {});
+  };
+
   // 플레이스토어용: 인앱 리뷰 시도 후, 안 되면 스토어 링크로 폴백
   const handleReviewPress = async () => {
     try {
@@ -23,7 +27,7 @@ const SettingsLinks: React.FC<SettingsLinksProps> = () => {
     } catch {
       // In-App Review 실패 시 아래 폴백으로 진행
     }
-    Linking.openURL(PLAY_STORE_URL).catch(() => {});
+    openExternalLink(PLAY_STORE_URL);
   };
 
   /*
@@ -35,11 +39,25 @@ const SettingsLinks: React.FC<SettingsLinksProps> = () => {
    * };
    */
 
+  const handleStoreLinkPress = () => {
+    openExternalLink(PLAY_STORE_URL);
+  };
+
+  const handleReleaseNotesPress = () => {
+    openExternalLink(RELEASE_NOTES_URL);
+  };
+
   const handleContactPress = () => {
     const subject = encodeURIComponent('어쩜! 단수 카운터 문의');
+    const body = encodeURIComponent(
+      [
+        '출시 버전* : (설정 페이지의 하단에서 확인해서 입력해주세요)',
+        '기기 정보 : ',
+      ].join('\n')
+    );
     const email = 'Gaebal0201@gmail.com';
-    const url = `mailto:${email}?subject=${subject}`;
-    Linking.openURL(url).catch(() => {});
+    const url = `mailto:${email}?subject=${subject}&body=${body}`;
+    openExternalLink(url);
   };
 
   return (
@@ -53,6 +71,16 @@ const SettingsLinks: React.FC<SettingsLinksProps> = () => {
         title="문의하기"
         iconName="mail"
         onPress={handleContactPress}
+      />
+      <IconBox
+        title="스토어 링크"
+        iconName="external-link"
+        onPress={handleStoreLinkPress}
+      />
+      <IconBox
+        title="출시 노트"
+        iconName="file-text"
+        onPress={handleReleaseNotesPress}
       />
     </View>
   );

--- a/src/constants/storeUrls.ts
+++ b/src/constants/storeUrls.ts
@@ -4,6 +4,7 @@
 export const ONE_STORE_URL = 'https://onesto.re/0001001132';
 export const PLAY_STORE_URL =
   'https://play.google.com/store/apps/details?id=com.simpleknitcounter&pcampaignid=web_share';
+export const RELEASE_NOTES_URL = 'https://rust-bar-a36.notion.site/1fdd2ea9da7d80d3a286f1fb83d21ed3?source=copy_link';
 
 /** 원스토어 설치 시 getInstallerPackageName() 반환값 */
 export const ONE_STORE_INSTALLER_PACKAGE = 'com.skt.skaf.A000Z00040';

--- a/src/screens/Setting.tsx
+++ b/src/screens/Setting.tsx
@@ -1,9 +1,10 @@
 // src/screens/Settings.tsx
 import React from 'react';
-import { View, ScrollView } from 'react-native';
+import { ScrollView } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { SettingsCheckBoxes, SettingsLinks, SettingsVersion } from '@components/settings';
-import { screenStyles } from '@styles/screenStyles';
+import { screenStyles, safeAreaEdges } from '@styles/screenStyles';
 
 /**
  * 설정 화면 컴포넌트
@@ -12,7 +13,7 @@ import { screenStyles } from '@styles/screenStyles';
 const Settings = () => {
 
   return (
-    <View className="flex-1">
+    <SafeAreaView style={screenStyles.flex1} edges={safeAreaEdges}>
       {/* 설정 옵션들 */}
       <ScrollView contentContainerStyle={screenStyles.scrollViewContentCentered}>
         <SettingsCheckBoxes />
@@ -21,8 +22,7 @@ const Settings = () => {
 
         <SettingsVersion version="1.3.3-internal.1" />
       </ScrollView>
-
-    </View>
+    </SafeAreaView>
   );
 };
 


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #134 


## 🛠 작업 내용

사진1 : 수정 전
사진2 : 수정 후
<p float="left">
<img width="48%" alt="image" src="https://github.com/user-attachments/assets/e0dc7830-7994-4aa5-bb8e-27d1ec0f4781" />
<img width="48%" alt="image" src="https://github.com/user-attachments/assets/78cacac5-9ca2-4d15-b1a3-c7f4ef7dec18" />
</p>

- 설정 체크박스는 표시 순서를 변경하고 섹션을 나누어 설정을 찾기 쉽고 직관적이도록 변경했습니다.
- 설정 버튼에 출시 노트, 스토어 링크를 추가했습니다.
- 설정 페이지 내용이 길어짐에 따라 safeAreaView가 필요하여 추가했습니다.

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)

- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 시스템 폰트 사이즈, 화면 크기 변화에 대응하는 걸 확인했습니다.
- [x] 동료 작업자에게 수정 사항을 공유했습니다. 