### PR TITLE
fix: 중복 이름 모달이 기존 모달 위에 뜨지 않는 현상

### DIFF
--- a/src/components/common/modals/CounterCreateModal/CounterCreateModal.tsx
+++ b/src/components/common/modals/CounterCreateModal/CounterCreateModal.tsx
@@ -1,5 +1,5 @@
 // src/components/common/modals/CounterCreateModal/CounterCreateModal.tsx
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { View } from 'react-native';
 import { BaseModal } from '../BaseModal';
 import TextInputBox from '@components/common/TextInputBox';
@@ -9,13 +9,13 @@ import RoundedButton from '@components/common/RoundedButton';
  * CounterCreateModal 컴포넌트의 Props 인터페이스
  * @param visible - 모달 표시 여부
  * @param onClose - 모달 닫기 콜백 함수
- * @param onConfirm - 생성 확인 시 콜백 함수
+ * @param onConfirm - 생성 확인 시 콜백. `false`를 반환하면 모달을 닫지 않음(예: 중복 확인 모달 위에 유지)
  * @param title - 모달 제목 (기본값: '새 카운터 생성하기')
  */
 interface CounterCreateModalProps {
   visible: boolean;
   onClose: () => void;
-  onConfirm: (name: string) => void;
+  onConfirm: (name: string) => boolean | void;
   title?: string;
 }
 
@@ -31,11 +31,19 @@ const CounterCreateModal: React.FC<CounterCreateModalProps> = ({
 }) => {
   const [textValue, setTextValue] = useState('');
 
+  useEffect(() => {
+    if (!visible) {
+      setTextValue('');
+    }
+  }, [visible]);
+
   const handleConfirm = () => {
     if (textValue.trim()) {
-      onConfirm(textValue.trim());
-      setTextValue('');
-      onClose();
+      const keepOpen = onConfirm(textValue.trim()) === false;
+      if (!keepOpen) {
+        setTextValue('');
+        onClose();
+      }
     }
   };
 

--- a/src/components/common/modals/ProjectCreateModal/ProjectCreateModal.tsx
+++ b/src/components/common/modals/ProjectCreateModal/ProjectCreateModal.tsx
@@ -1,5 +1,5 @@
 // src/components/common/modals/ProjectCreateModal/ProjectCreateModal.tsx
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { View } from 'react-native';
 import { BaseModal } from '../BaseModal';
 import TextInputBox from '@components/common/TextInputBox';
@@ -10,12 +10,12 @@ import ProjectTypeSelector from './ProjectTypeSelector';
  * ProjectCreateModal 컴포넌트의 Props 인터페이스
  * @param visible - 모달 표시 여부
  * @param onClose - 모달 닫기 콜백 함수
- * @param onConfirm - 생성 확인 시 콜백 함수
+ * @param onConfirm - 생성 확인 시 콜백. `false`를 반환하면 모달을 닫지 않음(예: 중복 확인 모달 위에 유지)
  */
 interface ProjectCreateModalProps {
   visible: boolean;
   onClose: () => void;
-  onConfirm: (name: string, type: 'project' | 'counter') => void;
+  onConfirm: (name: string, type: 'project' | 'counter') => boolean | void;
   title?: string;
 }
 
@@ -32,12 +32,21 @@ const ProjectCreateModal: React.FC<ProjectCreateModalProps> = ({
   const [textValue, setTextValue] = useState('');
   const [selectedType, setSelectedType] = useState<'project' | 'counter'>('counter');
 
-  const handleConfirm = () => {
-    if (textValue.trim()) {
-      onConfirm(textValue.trim(), selectedType);
+  useEffect(() => {
+    if (!visible) {
       setTextValue('');
       setSelectedType('counter');
-      onClose();
+    }
+  }, [visible]);
+
+  const handleConfirm = () => {
+    if (textValue.trim()) {
+      const keepOpen = onConfirm(textValue.trim(), selectedType) === false;
+      if (!keepOpen) {
+        setTextValue('');
+        setSelectedType('counter');
+        onClose();
+      }
     }
   };
 

--- a/src/hooks/useMain.ts
+++ b/src/hooks/useMain.ts
@@ -126,10 +126,11 @@ export const useMain = () => {
     if (checkDuplicateName(newItem)) {
       setPendingItem(newItem);
       setDuplicateModalVisible(true);
-      return;
+      return false;
     }
 
     completeItemCreation(newItem);
+    return true;
   }, [createNewItem, checkDuplicateName, completeItemCreation, setPendingItem, setDuplicateModalVisible]);
 
   /**

--- a/src/hooks/useProjectDetail.ts
+++ b/src/hooks/useProjectDetail.ts
@@ -148,7 +148,7 @@ export const useProjectDetail = () => {
    */
   const handleCreateCounterConfirm = useCallback((name?: string) => {
     if (!name?.trim()) {
-      return;
+      return false;
     }
 
     const newCounter = createNewCounter(name);
@@ -156,10 +156,11 @@ export const useProjectDetail = () => {
     if (checkDuplicateName(newCounter)) {
       setPendingItem(newCounter);
       setDuplicateModalVisible(true);
-      return;
+      return false;
     }
 
     completeCounterCreation(newCounter);
+    return true;
   }, [createNewCounter, checkDuplicateName, completeCounterCreation, setPendingItem, setDuplicateModalVisible]);
 
   /**


### PR DESCRIPTION


## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #25 


## 🛠 작업 내용

- confirm할 때 onclose를 항상 호출하지 않도록 수정하여 모달이 겹쳐서 뜰 수 있도록 하였음.

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)

- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 시스템 폰트 사이즈, 화면 크기 변화에 대응하는 걸 확인했습니다.
- [x] 동료 작업자에게 수정 사항을 공유했습니다. 