### PR TITLE
fix: 애니메이션 줄임 설정일 때 모달 렌더링이 (0,0)에 되는 프레임이 보이는 현상

### DIFF
--- a/src/components/common/modals/BaseModal/BaseModal.tsx
+++ b/src/components/common/modals/BaseModal/BaseModal.tsx
@@ -1,6 +1,7 @@
 // src/components/common/modals/BaseModal/BaseModal.tsx
-import React from 'react';
-import { Modal, Text, Pressable, View } from 'react-native';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Modal, Text, Pressable, View, StyleSheet } from 'react-native';
+import { usePreferReducedMotion } from '@hooks/usePreferReducedMotion';
 import { modalStyles } from '@styles/modalStyle';
 
 /**
@@ -27,28 +28,126 @@ const BaseModal: React.FC<BaseModalProps> = ({
   title,
   children,
 }) => {
+  const preferReducedMotion = usePreferReducedMotion();
+  const [contentReady, setContentReady] = useState(false);
+  /** 네이티브 onShow + 제목·children이 포함된 영역 레이아웃 완료 후에만 표시 */
+  const gatesRef = useRef({ show: false, innerLayout: false });
+  const rafRef = useRef<{ a?: number; b?: number }>({});
+  const visibleRef = useRef(visible);
+
+  useEffect(() => {
+    visibleRef.current = visible;
+  }, [visible]);
+
+  const clearRevealRaf = useCallback(() => {
+    if (rafRef.current.a != null) {
+      cancelAnimationFrame(rafRef.current.a);
+    }
+    if (rafRef.current.b != null) {
+      cancelAnimationFrame(rafRef.current.b);
+    }
+    rafRef.current = {};
+  }, []);
+
+  const scheduleReveal = useCallback(() => {
+    if (!visibleRef.current) {
+      return;
+    }
+    if (!gatesRef.current.show || !gatesRef.current.innerLayout) {
+      return;
+    }
+    clearRevealRaf();
+    rafRef.current.a = requestAnimationFrame(() => {
+      rafRef.current.b = requestAnimationFrame(() => {
+        if (visibleRef.current) {
+          setContentReady(true);
+        }
+      });
+    });
+  }, [clearRevealRaf]);
+
+  useEffect(() => {
+    gatesRef.current = { show: false, innerLayout: false };
+    setContentReady(false);
+    clearRevealRaf();
+  }, [visible, clearRevealRaf]);
+
+  useEffect(() => {
+    if (!visible) {
+      return;
+    }
+    const fallbackMs = 500;
+    const t = setTimeout(() => {
+      if (!visibleRef.current) {
+        return;
+      }
+      setContentReady((prev) => (prev ? prev : true));
+    }, fallbackMs);
+    return () => clearTimeout(t);
+  }, [visible]);
+
+  useEffect(
+    () => () => {
+      clearRevealRaf();
+    },
+    [clearRevealRaf],
+  );
+
+  const handleModalShow = useCallback(() => {
+    gatesRef.current.show = true;
+    scheduleReveal();
+  }, [scheduleReveal]);
+
+  const handleInnerLayout = useCallback(() => {
+    gatesRef.current.innerLayout = true;
+    scheduleReveal();
+  }, [scheduleReveal]);
+
   return (
     <Modal
       visible={visible}
       transparent
-      animationType="fade"
+      animationType={preferReducedMotion ? 'none' : 'fade'}
       onRequestClose={onClose}
+      onShow={handleModalShow}
     >
       <View style={modalStyles.overlay}>
         {/* 배경 터치 영역 */}
         <Pressable style={modalStyles.backdrop} onPress={onClose} />
 
-        {/* 모달 컨테이너 */}
-        <View style={modalStyles.container}>
-          {/* 모달 제목 */}
-          <Text style={modalStyles.title}>{title}</Text>
+        {/* 모달 컨테이너 — 네이티브 표시·카드 레이아웃·자식 측정이 끝날 때까지 숨김 */}
+        <View
+          style={[
+            modalStyles.container,
+            !contentReady && baseModalStyles.containerHidden,
+          ]}
+          collapsable={false}
+        >
+          <View
+            collapsable={false}
+            style={baseModalStyles.innerStack}
+            onLayout={handleInnerLayout}
+          >
+            {/* 모달 제목 */}
+            <Text style={modalStyles.title}>{title}</Text>
 
-          {/* 모달 내용 */}
-          {children}
+            {/* 모달 내용 */}
+            {children}
+          </View>
         </View>
       </View>
     </Modal>
   );
 };
+
+const baseModalStyles = StyleSheet.create({
+  containerHidden: {
+    opacity: 0,
+  },
+  /** modalStyles.container의 gap과 동일 — 내부 래퍼가 자식이 되면서 밖의 gap이 적용되지 않음 */
+  innerStack: {
+    gap: 12,
+  },
+});
 
 export default BaseModal;

--- a/src/components/common/modals/BaseModal/BaseModal.tsx
+++ b/src/components/common/modals/BaseModal/BaseModal.tsx
@@ -30,68 +30,39 @@ const BaseModal: React.FC<BaseModalProps> = ({
 }) => {
   const preferReducedMotion = usePreferReducedMotion();
   const [contentReady, setContentReady] = useState(false);
-  /** 네이티브 onShow + 제목·children이 포함된 영역 레이아웃 완료 후에만 표시 */
   const gatesRef = useRef({ show: false, innerLayout: false });
-  const rafRef = useRef<{ a?: number; b?: number }>({});
+  const rafRef = useRef<number | undefined>(undefined);
   const visibleRef = useRef(visible);
 
   useEffect(() => {
     visibleRef.current = visible;
   }, [visible]);
 
-  const clearRevealRaf = useCallback(() => {
-    if (rafRef.current.a != null) {
-      cancelAnimationFrame(rafRef.current.a);
+  const cancelRevealRaf = useCallback(() => {
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = undefined;
     }
-    if (rafRef.current.b != null) {
-      cancelAnimationFrame(rafRef.current.b);
-    }
-    rafRef.current = {};
   }, []);
 
   const scheduleReveal = useCallback(() => {
-    if (!visibleRef.current) {
+    if (!visibleRef.current || !gatesRef.current.show || !gatesRef.current.innerLayout) {
       return;
     }
-    if (!gatesRef.current.show || !gatesRef.current.innerLayout) {
-      return;
-    }
-    clearRevealRaf();
-    rafRef.current.a = requestAnimationFrame(() => {
-      rafRef.current.b = requestAnimationFrame(() => {
-        if (visibleRef.current) {
-          setContentReady(true);
-        }
-      });
+    cancelRevealRaf();
+    rafRef.current = requestAnimationFrame(() => {
+      if (visibleRef.current) {
+        setContentReady(true);
+      }
     });
-  }, [clearRevealRaf]);
+  }, [cancelRevealRaf]);
 
   useEffect(() => {
     gatesRef.current = { show: false, innerLayout: false };
     setContentReady(false);
-    clearRevealRaf();
-  }, [visible, clearRevealRaf]);
-
-  useEffect(() => {
-    if (!visible) {
-      return;
-    }
-    const fallbackMs = 500;
-    const t = setTimeout(() => {
-      if (!visibleRef.current) {
-        return;
-      }
-      setContentReady((prev) => (prev ? prev : true));
-    }, fallbackMs);
-    return () => clearTimeout(t);
-  }, [visible]);
-
-  useEffect(
-    () => () => {
-      clearRevealRaf();
-    },
-    [clearRevealRaf],
-  );
+    cancelRevealRaf();
+    return cancelRevealRaf;
+  }, [visible, cancelRevealRaf]);
 
   const handleModalShow = useCallback(() => {
     gatesRef.current.show = true;
@@ -112,10 +83,8 @@ const BaseModal: React.FC<BaseModalProps> = ({
       onShow={handleModalShow}
     >
       <View style={modalStyles.overlay}>
-        {/* 배경 터치 영역 */}
         <Pressable style={modalStyles.backdrop} onPress={onClose} />
 
-        {/* 모달 컨테이너 — 네이티브 표시·카드 레이아웃·자식 측정이 끝날 때까지 숨김 */}
         <View
           style={[
             modalStyles.container,
@@ -128,10 +97,7 @@ const BaseModal: React.FC<BaseModalProps> = ({
             style={baseModalStyles.innerStack}
             onLayout={handleInnerLayout}
           >
-            {/* 모달 제목 */}
             <Text style={modalStyles.title}>{title}</Text>
-
-            {/* 모달 내용 */}
             {children}
           </View>
         </View>
@@ -144,7 +110,6 @@ const baseModalStyles = StyleSheet.create({
   containerHidden: {
     opacity: 0,
   },
-  /** modalStyles.container의 gap과 동일 — 내부 래퍼가 자식이 되면서 밖의 gap이 적용되지 않음 */
   innerStack: {
     gap: 12,
   },

--- a/src/components/common/modals/BaseModal/BaseModal.tsx
+++ b/src/components/common/modals/BaseModal/BaseModal.tsx
@@ -1,5 +1,5 @@
 // src/components/common/modals/BaseModal/BaseModal.tsx
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { Modal, Text, Pressable, View, StyleSheet } from 'react-native';
 import { usePreferReducedMotion } from '@hooks/usePreferReducedMotion';
 import { modalStyles } from '@styles/modalStyle';
@@ -57,7 +57,7 @@ const BaseModal: React.FC<BaseModalProps> = ({
     });
   }, [cancelRevealRaf]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     gatesRef.current = { show: false, innerLayout: false };
     setContentReady(false);
     cancelRevealRaf();

--- a/src/components/common/modals/BaseModal/BaseModal.tsx
+++ b/src/components/common/modals/BaseModal/BaseModal.tsx
@@ -83,8 +83,10 @@ const BaseModal: React.FC<BaseModalProps> = ({
       onShow={handleModalShow}
     >
       <View style={modalStyles.overlay}>
+        {/* 배경 터치 영역 */}
         <Pressable style={modalStyles.backdrop} onPress={onClose} />
 
+        {/* 모달 컨테이너 */}
         <View
           style={[
             modalStyles.container,
@@ -92,12 +94,15 @@ const BaseModal: React.FC<BaseModalProps> = ({
           ]}
           collapsable={false}
         >
+          {/* 모달 내용 영역 */}
           <View
             collapsable={false}
             style={baseModalStyles.innerStack}
             onLayout={handleInnerLayout}
           >
+            {/* 모달 제목 */}
             <Text style={modalStyles.title}>{title}</Text>
+            {/* 모달 내용(children) */}
             {children}
           </View>
         </View>

--- a/src/components/list/SortDropdown.tsx
+++ b/src/components/list/SortDropdown.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import { Modal, View, Text, Pressable, TouchableOpacity, StyleSheet } from 'react-native';
+import React, { useState, useEffect } from 'react';
+import { Modal, View, Text, Pressable, TouchableOpacity } from 'react-native';
 import CheckBox from '@components/common/CheckBox';
 import { usePreferReducedMotion } from '@hooks/usePreferReducedMotion';
 import {
@@ -49,17 +49,6 @@ const SortDropdown: React.FC<SortDropdownProps> = ({
   });
 
   const preferReducedMotion = usePreferReducedMotion();
-  const [backdropLaidOut, setBackdropLaidOut] = useState(false);
-
-  useEffect(() => {
-    if (visible) {
-      setBackdropLaidOut(false);
-    }
-  }, [visible]);
-
-  const handleBackdropLayout = useCallback(() => {
-    setBackdropLaidOut(true);
-  }, []);
 
   // visible이 true가 될 때마다 storage에서 최신 값 가져오기
   useEffect(() => {
@@ -119,14 +108,9 @@ const SortDropdown: React.FC<SortDropdownProps> = ({
       animationType={preferReducedMotion ? 'none' : 'fade'}
       onRequestClose={onClose}
     >
-      <Pressable
-        className="flex-1"
-        onPress={onClose}
-        onLayout={handleBackdropLayout}
-      >
+      <Pressable className="flex-1" onPress={onClose}>
         <Pressable
           className="absolute right-3 top-16 bg-white rounded-2xl w-40 p-4 shadow-lg"
-          style={!backdropLaidOut ? sortDropdownStyles.panelHidden : undefined}
           onPress={(e) => e.stopPropagation()}
         >
           <Text className="text-s font-bold text-black mb-2">정렬</Text>
@@ -215,11 +199,5 @@ const SortDropdown: React.FC<SortDropdownProps> = ({
     </Modal>
   );
 };
-
-const sortDropdownStyles = StyleSheet.create({
-  panelHidden: {
-    opacity: 0,
-  },
-});
 
 export default SortDropdown;

--- a/src/components/list/SortDropdown.tsx
+++ b/src/components/list/SortDropdown.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect } from 'react';
-import { Modal, View, Text, Pressable, TouchableOpacity } from 'react-native';
+import React, { useState, useEffect, useCallback } from 'react';
+import { Modal, View, Text, Pressable, TouchableOpacity, StyleSheet } from 'react-native';
 import CheckBox from '@components/common/CheckBox';
+import { usePreferReducedMotion } from '@hooks/usePreferReducedMotion';
 import {
   getSortCriteriaSetting,
   setSortCriteriaSetting,
@@ -46,6 +47,19 @@ const SortDropdown: React.FC<SortDropdownProps> = ({
   const [showElapsedTimeInList, setShowElapsedTimeInList] = useState<boolean>(() => {
     return getShowElapsedTimeInListSetting();
   });
+
+  const preferReducedMotion = usePreferReducedMotion();
+  const [backdropLaidOut, setBackdropLaidOut] = useState(false);
+
+  useEffect(() => {
+    if (visible) {
+      setBackdropLaidOut(false);
+    }
+  }, [visible]);
+
+  const handleBackdropLayout = useCallback(() => {
+    setBackdropLaidOut(true);
+  }, []);
 
   // visible이 true가 될 때마다 storage에서 최신 값 가져오기
   useEffect(() => {
@@ -102,15 +116,17 @@ const SortDropdown: React.FC<SortDropdownProps> = ({
     <Modal
       visible={visible}
       transparent
-      animationType="fade"
+      animationType={preferReducedMotion ? 'none' : 'fade'}
       onRequestClose={onClose}
     >
       <Pressable
         className="flex-1"
         onPress={onClose}
+        onLayout={handleBackdropLayout}
       >
         <Pressable
           className="absolute right-3 top-16 bg-white rounded-2xl w-40 p-4 shadow-lg"
+          style={!backdropLaidOut ? sortDropdownStyles.panelHidden : undefined}
           onPress={(e) => e.stopPropagation()}
         >
           <Text className="text-s font-bold text-black mb-2">정렬</Text>
@@ -199,5 +215,11 @@ const SortDropdown: React.FC<SortDropdownProps> = ({
     </Modal>
   );
 };
+
+const sortDropdownStyles = StyleSheet.create({
+  panelHidden: {
+    opacity: 0,
+  },
+});
 
 export default SortDropdown;

--- a/src/hooks/usePreferReducedMotion.ts
+++ b/src/hooks/usePreferReducedMotion.ts
@@ -7,11 +7,21 @@ export const usePreferReducedMotion = (): boolean => {
 
   useEffect(() => {
     let cancelled = false;
-    AccessibilityInfo.isReduceMotionEnabled().then((enabled) => {
-      if (!cancelled) {
-        setPreferReducedMotion(enabled);
-      }
-    });
+    AccessibilityInfo.isReduceMotionEnabled()
+      .then((enabled) => {
+        if (!cancelled) {
+          setPreferReducedMotion(enabled);
+        }
+      })
+      .catch((error: unknown) => {
+        if (cancelled) {
+          return;
+        }
+        console.warn(
+          'usePreferReducedMotion: isReduceMotionEnabled failed',
+          error,
+        );
+      });
     const subscription = AccessibilityInfo.addEventListener(
       'reduceMotionChanged',
       setPreferReducedMotion,

--- a/src/hooks/usePreferReducedMotion.ts
+++ b/src/hooks/usePreferReducedMotion.ts
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+import { AccessibilityInfo } from 'react-native';
+
+/**
+ * 접근성의 "동작 줄이기"(iOS Reduce Motion, Android에서도 동일 API로 반영) 여부.
+ * 시스템 애니메이션을 끈 환경에서 네이티브 Modal fade 등과 충돌할 때 사용한다.
+ */
+export const usePreferReducedMotion = (): boolean => {
+  const [preferReducedMotion, setPreferReducedMotion] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    AccessibilityInfo.isReduceMotionEnabled().then((enabled) => {
+      if (!cancelled) {
+        setPreferReducedMotion(enabled);
+      }
+    });
+    const subscription = AccessibilityInfo.addEventListener(
+      'reduceMotionChanged',
+      (enabled: boolean) => {
+        setPreferReducedMotion(enabled);
+      },
+    );
+    return () => {
+      cancelled = true;
+      subscription.remove();
+    };
+  }, []);
+
+  return preferReducedMotion;
+};

--- a/src/hooks/usePreferReducedMotion.ts
+++ b/src/hooks/usePreferReducedMotion.ts
@@ -1,10 +1,7 @@
 import { useEffect, useState } from 'react';
 import { AccessibilityInfo } from 'react-native';
 
-/**
- * 접근성의 "동작 줄이기"(iOS Reduce Motion, Android에서도 동일 API로 반영) 여부.
- * 시스템 애니메이션을 끈 환경에서 네이티브 Modal fade 등과 충돌할 때 사용한다.
- */
+/** 접근성 "동작 줄이기" — Modal 네이티브 fade와 맞출 때 사용 */
 export const usePreferReducedMotion = (): boolean => {
   const [preferReducedMotion, setPreferReducedMotion] = useState(false);
 
@@ -17,9 +14,7 @@ export const usePreferReducedMotion = (): boolean => {
     });
     const subscription = AccessibilityInfo.addEventListener(
       'reduceMotionChanged',
-      (enabled: boolean) => {
-        setPreferReducedMotion(enabled);
-      },
+      setPreferReducedMotion,
     );
     return () => {
       cancelled = true;


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #29 


## 🛠 작업 내용

이전에는 android기기 애니메이션 줄임 설정이 켜져 있으면
다음과 같이 모달을 열 때 좌상단(0, 0) 지점에 컴포넌트가 렌더링되는 프레임을 확인할 수 있었음. 
https://github.com/user-attachments/assets/9a72a5cf-d651-4794-b750-a11381f0c410

이를 없앰.
- BaseModal에서 카드와 children이 제목·내용을 감싼 내부 뷰의 onLayout까지 끝난 뒤에만 opacity로 보이게 했고, 그 직전에 한 번 requestAnimationFrame을 걸어 레이아웃·페인트 순서가 맞은 다음에 그리도록 하였음
- 애니메이션 줄이기가 켜진 기기에서는 AccessibilityInfo로 감지해 animationType을 none으로 두어 네이티브 페이드와 첫 프레임이 겹치지 않게 했습니다.

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)

- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 시스템 폰트 사이즈, 화면 크기 변화에 대응하는 걸 확인했습니다.
- [x] 동료 작업자에게 수정 사항을 공유했습니다. 