### PR TITLE
refactor: 툴팁 투명도 변경 및 슬라이드 모달 컴포넌트에 적용

### DIFF
--- a/src/components/common/Tooltip.tsx
+++ b/src/components/common/Tooltip.tsx
@@ -31,22 +31,37 @@ const Tooltip: React.FC<TooltipProps> = ({
   /** 화살표·박스 경계 서브픽셀 틈 방지(1px만 박스 쪽으로 겹침; 삼각형 스케일 키우는 것과 달리 두께는 그대로) */
   const ARROW_BOX_OVERLAP_PX = 1;
 
+  /** auto-hide 완료 시점의 visuallyHidden(타이머는 마운트당 1회만 — deps에 넣지 않음) */
+  const visuallyHiddenRef = useRef(visuallyHidden);
+  visuallyHiddenRef.current = visuallyHidden;
+
   useEffect(() => {
     if (AUTO_HIDE_MS <= 0) {
-      return;
+      return undefined;
     }
+    let cancelled = false;
     const t = setTimeout(() => {
+      if (cancelled) {
+        return;
+      }
       Animated.timing(opacity, {
         toValue: 0,
         duration: FADE_OUT_MS,
         useNativeDriver: true,
       }).start(({ finished }) => {
-        if (finished) {
+        if (cancelled || !finished) {
+          return;
+        }
+        if (!visuallyHiddenRef.current) {
           setVisible(false);
         }
       });
     }, AUTO_HIDE_MS);
-    return () => clearTimeout(t);
+    return () => {
+      cancelled = true;
+      clearTimeout(t);
+      opacity.stopAnimation();
+    };
   }, [AUTO_HIDE_MS, FADE_OUT_MS, opacity]);
 
   // targetAnchorX가 바뀌면(ex: onLayout으로 resolvedWidth 갱신)

--- a/src/components/common/Tooltip.tsx
+++ b/src/components/common/Tooltip.tsx
@@ -18,6 +18,8 @@ const Tooltip: React.FC<TooltipProps> = ({ text, containerClassName, targetAncho
   const bodyRef = useRef<View | null>(null);
   const [arrowLeftPx, setArrowLeftPx] = useState<number | null>(null);
   const ARROW_HALF_WIDTH = 6; // Svg width 12 기준
+  /** 화살표·박스 경계 서브픽셀 틈 방지(1px만 박스 쪽으로 겹침; 삼각형 스케일 키우는 것과 달리 두께는 그대로) */
+  const ARROW_BOX_OVERLAP_PX = 1;
 
   useEffect(() => {
     if (AUTO_HIDE_MS > 0) {
@@ -62,7 +64,12 @@ const Tooltip: React.FC<TooltipProps> = ({ text, containerClassName, targetAncho
           <Svg
             width={12}
             height={20}
-            style={{ position: 'absolute', left: arrowLeftPx ?? '50%', top: -8, transform: [{ translateX: -(arrowLeftPx != null ? ARROW_HALF_WIDTH : 6) }] }}
+            style={{
+              position: 'absolute',
+              left: arrowLeftPx ?? '50%',
+              top: -8 + ARROW_BOX_OVERLAP_PX,
+              transform: [{ translateX: -(arrowLeftPx != null ? ARROW_HALF_WIDTH : 6) }],
+            }}
           >
             <Path d="M0 20 L5 5 Q6 4 7 5 L12 20 Z" fill="rgba(0,0,0,0.6)" />
           </Svg>

--- a/src/components/common/Tooltip.tsx
+++ b/src/components/common/Tooltip.tsx
@@ -83,9 +83,7 @@ const Tooltip: React.FC<TooltipProps> = ({
               style={{ maxWidth: 240, marginLeft: -ARROW_BOX_OVERLAP_PX }}
             >
               {text ? (
-                <Text className="text-white text-xs text-center" allowFontScaling={false}>
-                  {text}
-                </Text>
+                <Text className="text-white text-xs text-center">{text}</Text>
               ) : null}
             </View>
           </View>
@@ -131,9 +129,7 @@ const Tooltip: React.FC<TooltipProps> = ({
               }}
             >
               {text ? (
-                <Text className="text-white text-xs text-center" allowFontScaling={false}>
-                  {text}
-                </Text>
+                <Text className="text-white text-xs text-center">{text}</Text>
               ) : null}
             </View>
           </View>

--- a/src/components/common/Tooltip.tsx
+++ b/src/components/common/Tooltip.tsx
@@ -76,10 +76,10 @@ const Tooltip: React.FC<TooltipProps> = ({
           <View className="relative flex-row items-center">
             {/* placement top의 Path를 -90° 회전한 형태와 동일한 둥근 삼각형(왼쪽 끝이 뾰족, 오른쪽이 밑변) */}
             <Svg width={20} height={12} viewBox="0 0 20 12">
-              <Path d="M20 0 L6 5 Q5 6 6 7 L20 12 Z" fill="rgba(0,0,0,0.6)" />
+              <Path d="M20 0 L6 5 Q5 6 6 7 L20 12 Z" fill="rgba(0,0,0,1)" />
             </Svg>
             <View
-              className="rounded-md bg-black/60 px-2 py-3"
+              className="rounded-md bg-black px-2 py-3"
               style={{ maxWidth: 240, marginLeft: -ARROW_BOX_OVERLAP_PX }}
             >
               {text ? (
@@ -112,11 +112,11 @@ const Tooltip: React.FC<TooltipProps> = ({
                 ],
               }}
             >
-              <Path d="M0 20 L5 5 Q6 4 7 5 L12 20 Z" fill="rgba(0,0,0,0.6)" />
+              <Path d="M0 20 L5 5 Q6 4 7 5 L12 20 Z" fill="rgba(0,0,0,1)" />
             </Svg>
             <View
               ref={(ref) => { bodyRef.current = ref; }}
-              className="px-2 py-3 rounded-md bg-black/60 mb-3"
+              className="px-2 py-3 rounded-md bg-black mb-3"
               style={{ maxWidth: 240 }}
               onLayout={(_e: LayoutChangeEvent) => {
                 if (!targetAnchorX || !bodyRef.current) {
@@ -158,11 +158,11 @@ const Tooltip: React.FC<TooltipProps> = ({
                 transform: [{ translateX: -(arrowLeftPx != null ? ARROW_HALF_WIDTH : 6) }],
               }}
             >
-              <Path d="M0 20 L5 5 Q6 4 7 5 L12 20 Z" fill="rgba(0,0,0,0.6)" />
+              <Path d="M0 20 L5 5 Q6 4 7 5 L12 20 Z" fill="rgba(0,0,0,1)" />
             </Svg>
             <View
               ref={(ref) => { bodyRef.current = ref; }}
-              className="px-2 py-3 rounded-md bg-black/60 mt-3"
+              className="px-2 py-3 rounded-md bg-black mt-3"
               style={{ maxWidth: 240 }}
               onLayout={(_e: LayoutChangeEvent) => {
                 if (!targetAnchorX || !bodyRef.current) {

--- a/src/components/common/Tooltip.tsx
+++ b/src/components/common/Tooltip.tsx
@@ -6,42 +6,53 @@ import Svg, { Path } from 'react-native-svg';
 interface TooltipProps {
   text?: string;
   containerClassName?: string;
-  // 화면 기준 타겟 X좌표(px). 제공되면 화살표를 해당 타겟을 향해 정렬
+  /** 기본: 위쪽 화살표 + 아래 박스. left: 왼쪽을 가리키는 화살표 + 오른쪽 텍스트 박스 */
+  placement?: 'top' | 'left';
+  // 화면 기준 타겟 X좌표(px). placement=top일 때 화살표 가로 정렬
   targetAnchorX?: number;
+  /** true: 언마운트 없이 투명 처리만(슬라이드 모달 열림 등). 4초 타이머는 마운트당 1회만 진행 */
+  visuallyHidden?: boolean;
 }
 
-const Tooltip: React.FC<TooltipProps> = ({ text, containerClassName, targetAnchorX }) => {
+const Tooltip: React.FC<TooltipProps> = ({
+  text,
+  containerClassName,
+  placement = 'top',
+  targetAnchorX,
+  visuallyHidden = false,
+}) => {
   const [visible, setVisible] = useState(true);
   const opacity = useRef(new Animated.Value(1)).current;
   const AUTO_HIDE_MS = 4000;
   const FADE_OUT_MS = 400;
   const bodyRef = useRef<View | null>(null);
   const [arrowLeftPx, setArrowLeftPx] = useState<number | null>(null);
-  const ARROW_HALF_WIDTH = 6; // Svg width 12 기준
+  const ARROW_HALF_WIDTH = 6; // Svg width 12 기준 (placement top)
   /** 화살표·박스 경계 서브픽셀 틈 방지(1px만 박스 쪽으로 겹침; 삼각형 스케일 키우는 것과 달리 두께는 그대로) */
   const ARROW_BOX_OVERLAP_PX = 1;
 
   useEffect(() => {
-    if (AUTO_HIDE_MS > 0) {
-      const t = setTimeout(() => {
-        Animated.timing(opacity, {
-          toValue: 0,
-          duration: FADE_OUT_MS,
-          useNativeDriver: true,
-        }).start(({ finished }) => {
-          if (finished) {
-            setVisible(false);
-          }
-        });
-      }, AUTO_HIDE_MS);
-      return () => clearTimeout(t);
+    if (AUTO_HIDE_MS <= 0) {
+      return;
     }
+    const t = setTimeout(() => {
+      Animated.timing(opacity, {
+        toValue: 0,
+        duration: FADE_OUT_MS,
+        useNativeDriver: true,
+      }).start(({ finished }) => {
+        if (finished) {
+          setVisible(false);
+        }
+      });
+    }, AUTO_HIDE_MS);
+    return () => clearTimeout(t);
   }, [AUTO_HIDE_MS, FADE_OUT_MS, opacity]);
 
   // targetAnchorX가 바뀌면(ex: onLayout으로 resolvedWidth 갱신)
-  // measureInWindow로 화살표 위치를 재계산
+  // measureInWindow로 화살표 위치를 재계산 (placement top 전용)
   useEffect(() => {
-    if (!targetAnchorX || !bodyRef.current) {
+    if (placement !== 'top' || !targetAnchorX || !bodyRef.current) {
       return;
     }
     bodyRef.current.measureInWindow((x, _y, w) => {
@@ -50,55 +61,83 @@ const Tooltip: React.FC<TooltipProps> = ({ text, containerClassName, targetAncho
       const clamped = Math.max(ARROW_HALF_WIDTH, Math.min(w - ARROW_HALF_WIDTH, raw));
       setArrowLeftPx(clamped);
     });
-  }, [targetAnchorX]);
+  }, [placement, targetAnchorX]);
 
   if (!visible) {
     return null;
   }
 
+  const hideWrapStyle = visuallyHidden ? { opacity: 0 as const } : undefined;
+
+  if (placement === 'left') {
+    return (
+      <View pointerEvents="none" className={containerClassName} style={hideWrapStyle}>
+        <Animated.View style={{ opacity }}>
+          <View className="relative flex-row items-center">
+            {/* placement top의 Path를 -90° 회전한 형태와 동일한 둥근 삼각형(왼쪽 끝이 뾰족, 오른쪽이 밑변) */}
+            <Svg width={20} height={12} viewBox="0 0 20 12">
+              <Path d="M20 0 L6 5 Q5 6 6 7 L20 12 Z" fill="rgba(0,0,0,0.6)" />
+            </Svg>
+            <View
+              className="rounded-md bg-black/60 px-2 py-3"
+              style={{ maxWidth: 240, marginLeft: -ARROW_BOX_OVERLAP_PX }}
+            >
+              {text ? (
+                <Text className="text-white text-xs text-center" allowFontScaling={false}>
+                  {text}
+                </Text>
+              ) : null}
+            </View>
+          </View>
+        </Animated.View>
+      </View>
+    );
+  }
+
   return (
-    <Animated.View pointerEvents="none" className={containerClassName} style={{ opacity }}>
-      <View className="relative self-center">
-        <View className="relative">
-          {/* 위쪽 삼각형 화살표 (SVG로 꼭짓점 자체를 둥글게) - 바로 아래 박스의 정확한 중앙에 정렬 */}
-          <Svg
-            width={12}
-            height={20}
-            style={{
-              position: 'absolute',
-              left: arrowLeftPx ?? '50%',
-              top: -8 + ARROW_BOX_OVERLAP_PX,
-              transform: [{ translateX: -(arrowLeftPx != null ? ARROW_HALF_WIDTH : 6) }],
-            }}
-          >
-            <Path d="M0 20 L5 5 Q6 4 7 5 L12 20 Z" fill="rgba(0,0,0,0.6)" />
-          </Svg>
-          <View
-            ref={(ref) => { bodyRef.current = ref; }}
-            className="px-2 py-3 rounded-md bg-black/60 mt-3"
-            style={{ maxWidth: 240 }}
-            onLayout={(_e: LayoutChangeEvent) => {
-              if (!targetAnchorX || !bodyRef.current) {
-                setArrowLeftPx(null); // 기본 중앙 정렬
-                return;
-              }
-              // 박스의 화면 기준 좌표를 가져와 타겟 X와의 차이로 화살표 위치(px) 계산
-              bodyRef.current.measureInWindow((x, _y, width) => {
-                const raw = targetAnchorX - x;
-                const clamped = Math.max(ARROW_HALF_WIDTH, Math.min(width - ARROW_HALF_WIDTH, raw));
-                setArrowLeftPx(clamped);
-              });
-            }}
-          >
-            {text ? (
-              <Text className="text-white text-xs text-center">{text}</Text>
-            ) : null}
+    <View pointerEvents="none" className={containerClassName} style={hideWrapStyle}>
+      <Animated.View style={{ opacity }}>
+        <View className="relative self-center">
+          <View className="relative">
+            {/* 위쪽 삼각형 화살표 (SVG로 꼭짓점 자체를 둥글게) - 바로 아래 박스의 정확한 중앙에 정렬 */}
+            <Svg
+              width={12}
+              height={20}
+              style={{
+                position: 'absolute',
+                left: arrowLeftPx ?? '50%',
+                top: -8 + ARROW_BOX_OVERLAP_PX,
+                transform: [{ translateX: -(arrowLeftPx != null ? ARROW_HALF_WIDTH : 6) }],
+              }}
+            >
+              <Path d="M0 20 L5 5 Q6 4 7 5 L12 20 Z" fill="rgba(0,0,0,0.6)" />
+            </Svg>
+            <View
+              ref={(ref) => { bodyRef.current = ref; }}
+              className="px-2 py-3 rounded-md bg-black/60 mt-3"
+              style={{ maxWidth: 240 }}
+              onLayout={(_e: LayoutChangeEvent) => {
+                if (!targetAnchorX || !bodyRef.current) {
+                  setArrowLeftPx(null); // 기본 중앙 정렬
+                  return;
+                }
+                // 박스의 화면 기준 좌표를 가져와 타겟 X와의 차이로 화살표 위치(px) 계산
+                bodyRef.current.measureInWindow((x, _y, width) => {
+                  const raw = targetAnchorX - x;
+                  const clamped = Math.max(ARROW_HALF_WIDTH, Math.min(width - ARROW_HALF_WIDTH, raw));
+                  setArrowLeftPx(clamped);
+                });
+              }}
+            >
+              {text ? (
+                <Text className="text-white text-xs text-center">{text}</Text>
+              ) : null}
+            </View>
           </View>
         </View>
-      </View>
-    </Animated.View>
+      </Animated.View>
+    </View>
   );
 };
 
 export default Tooltip;
-

--- a/src/components/common/Tooltip.tsx
+++ b/src/components/common/Tooltip.tsx
@@ -6,9 +6,9 @@ import Svg, { Path } from 'react-native-svg';
 interface TooltipProps {
   text?: string;
   containerClassName?: string;
-  /** 기본: 위쪽 화살표 + 아래 박스. left: 왼쪽을 가리키는 화살표 + 오른쪽 텍스트 박스 */
-  placement?: 'top' | 'left';
-  // 화면 기준 타겟 X좌표(px). placement=top일 때 화살표 가로 정렬
+  /** top: 위 화살표+아래 박스. bottom: 위 박스+아래 화살표(아래 방향). left: 왼쪽 화살+오른쪽 박스 */
+  placement?: 'top' | 'bottom' | 'left';
+  // 화면 기준 타겟 X좌표(px). placement top/bottom일 때 화살표 가로 정렬
   targetAnchorX?: number;
   /** true: 언마운트 없이 투명 처리만(슬라이드 모달 열림 등). 4초 타이머는 마운트당 1회만 진행 */
   visuallyHidden?: boolean;
@@ -50,9 +50,9 @@ const Tooltip: React.FC<TooltipProps> = ({
   }, [AUTO_HIDE_MS, FADE_OUT_MS, opacity]);
 
   // targetAnchorX가 바뀌면(ex: onLayout으로 resolvedWidth 갱신)
-  // measureInWindow로 화살표 위치를 재계산 (placement top 전용)
+  // measureInWindow로 화살표 위치를 재계산 (placement top/bottom 전용)
   useEffect(() => {
-    if (placement !== 'top' || !targetAnchorX || !bodyRef.current) {
+    if ((placement !== 'top' && placement !== 'bottom') || !targetAnchorX || !bodyRef.current) {
       return;
     }
     bodyRef.current.measureInWindow((x, _y, w) => {
@@ -81,6 +81,54 @@ const Tooltip: React.FC<TooltipProps> = ({
             <View
               className="rounded-md bg-black/60 px-2 py-3"
               style={{ maxWidth: 240, marginLeft: -ARROW_BOX_OVERLAP_PX }}
+            >
+              {text ? (
+                <Text className="text-white text-xs text-center" allowFontScaling={false}>
+                  {text}
+                </Text>
+              ) : null}
+            </View>
+          </View>
+        </Animated.View>
+      </View>
+    );
+  }
+
+  if (placement === 'bottom') {
+    return (
+      <View pointerEvents="none" className={containerClassName} style={hideWrapStyle}>
+        <Animated.View style={{ opacity }}>
+          <View className="relative self-center">
+            <Svg
+              width={12}
+              height={20}
+              style={{
+                position: 'absolute',
+                left: arrowLeftPx ?? '50%',
+                bottom: -8 + ARROW_BOX_OVERLAP_PX,
+                transform: [
+                  { translateX: -(arrowLeftPx != null ? ARROW_HALF_WIDTH : 6) },
+                  { rotate: '180deg' },
+                ],
+              }}
+            >
+              <Path d="M0 20 L5 5 Q6 4 7 5 L12 20 Z" fill="rgba(0,0,0,0.6)" />
+            </Svg>
+            <View
+              ref={(ref) => { bodyRef.current = ref; }}
+              className="px-2 py-3 rounded-md bg-black/60 mb-3"
+              style={{ maxWidth: 240 }}
+              onLayout={(_e: LayoutChangeEvent) => {
+                if (!targetAnchorX || !bodyRef.current) {
+                  setArrowLeftPx(null);
+                  return;
+                }
+                bodyRef.current.measureInWindow((x, _y, width) => {
+                  const raw = targetAnchorX - x;
+                  const clamped = Math.max(ARROW_HALF_WIDTH, Math.min(width - ARROW_HALF_WIDTH, raw));
+                  setArrowLeftPx(clamped);
+                });
+              }}
             >
               {text ? (
                 <Text className="text-white text-xs text-center" allowFontScaling={false}>

--- a/src/components/common/modals/SlideModal/SlideModal.tsx
+++ b/src/components/common/modals/SlideModal/SlideModal.tsx
@@ -70,7 +70,6 @@ export const SlideModal: React.FC<SlideModalProps> = ({
     setTranslateX(newTranslateX);
   };
 
-
   // ===== 렌더링 =====
   return (
     <View

--- a/src/components/common/modals/SlideModal/SlideModal.tsx
+++ b/src/components/common/modals/SlideModal/SlideModal.tsx
@@ -15,6 +15,8 @@ interface SlideModalProps {
   padding?: number; // 모달 내부 패딩 (기본값: 20)
   centerY?: DimensionValue; // 모달 세로 중앙 위치 (기본값: '50%'). SlideModal이 translateY: -height/2 로 보정함.
   onClose?: () => void; // 닫기 콜백 (선택사항)
+  /** 닫힌 상태(핸들만 노출)일 때 패널 오른쪽 기준 위치에 고정. 드래그/열림 translateX에는 따르지 않음 */
+  sideTooltip?: React.ReactNode;
 }
 
 
@@ -33,6 +35,7 @@ export const SlideModal: React.FC<SlideModalProps> = ({
   padding = 20,
   centerY = '50%',
   onClose,
+  sideTooltip,
 }) => {
   // ===== 상태 관리 =====
   // 왼쪽 모달 기준:
@@ -134,6 +137,27 @@ export const SlideModal: React.FC<SlideModalProps> = ({
         onToggle={onToggle}
         onDragUpdate={handleDragUpdate}
       />
+
+      {sideTooltip != null ? (
+        <View
+          pointerEvents="none"
+          style={{
+            position: 'absolute',
+            top: centerY,
+            left: 0,
+            zIndex: 51,
+            height,
+            justifyContent: 'center',
+            paddingLeft: 8,
+            transform: [
+              { translateX: handleWidth },
+              { translateY: -height / 2 },
+            ],
+          }}
+        >
+          {sideTooltip}
+        </View>
+      ) : null}
     </View>
   );
 };

--- a/src/components/counter/QuestionMarkTooltip.tsx
+++ b/src/components/counter/QuestionMarkTooltip.tsx
@@ -160,11 +160,11 @@ const QuestionMarkTooltip: React.FC<QuestionMarkTooltipProps> = ({ tooltipText }
                       transform: [{ translateX: -(arrowLeftPx != null ? ARROW_HALF_WIDTH : 6) }, { rotate: '180deg' }],
                     }}
                   >
-                    <Path d="M0 20 L5 5 Q6 4 7 5 L12 20 Z" fill="rgba(0,0,0,0.6)" />
+                    <Path d="M0 20 L5 5 Q6 4 7 5 L12 20 Z" fill="rgba(0,0,0,1)" />
                   </Svg>
                   <View
                     ref={(ref) => { bodyRef.current = ref; }}
-                    className="px-2 py-3 rounded-md bg-black/60 mb-3"
+                    className="px-2 py-3 rounded-md bg-black mb-3"
                     style={{ maxWidth: 240 }}
                     onLayout={(_e: LayoutChangeEvent) => {
                       if (!iconCenterX || !bodyRef.current) {

--- a/src/components/counter/QuestionMarkTooltip.tsx
+++ b/src/components/counter/QuestionMarkTooltip.tsx
@@ -29,6 +29,8 @@ const QuestionMarkTooltip: React.FC<QuestionMarkTooltipProps> = ({ tooltipText }
   const AUTO_HIDE_MS = 4000;
   const FADE_OUT_MS = 400;
   const ARROW_HALF_WIDTH = 6; // SVG 화살표 너비 12px의 절반
+  /** 화살표·박스 경계 서브픽셀 틈 방지(1px만 박스 쪽으로 겹침) */
+  const ARROW_BOX_OVERLAP_PX = 1;
   const TOOLTIP_BOX_MAX_WIDTH = 240;
   const TOOLTIP_BOX_HALF_WIDTH = TOOLTIP_BOX_MAX_WIDTH / 2;
   const PADDING = 16; // 화면 양쪽 여백
@@ -154,7 +156,7 @@ const QuestionMarkTooltip: React.FC<QuestionMarkTooltipProps> = ({ tooltipText }
                     style={{
                       position: 'absolute',
                       left: arrowLeftPx ?? 120, // 기본값은 박스 중앙 (240px / 2 = 120px)
-                      bottom: -8,
+                      bottom: -8 + ARROW_BOX_OVERLAP_PX,
                       transform: [{ translateX: -(arrowLeftPx != null ? ARROW_HALF_WIDTH : 6) }, { rotate: '180deg' }],
                     }}
                   >

--- a/src/components/counter/SegmentRecordModal.tsx
+++ b/src/components/counter/SegmentRecordModal.tsx
@@ -19,6 +19,8 @@ interface SegmentRecordModalProps {
   height: number;
   centerY: DimensionValue;
   sectionRecords?: SectionRecord[];
+  /** SlideModal 패널 오른쪽에 표시 */
+  sideTooltip?: React.ReactNode;
 }
 
 // ===== 메인 컴포넌트 =====
@@ -32,6 +34,7 @@ export const SegmentRecordModal: React.FC<SegmentRecordModalProps> = ({
   height,
   centerY,
   sectionRecords = [],
+  sideTooltip,
 }) => {
   const [showAllRecordsModal, setShowAllRecordsModal] = useState(false);
 
@@ -48,6 +51,7 @@ export const SegmentRecordModal: React.FC<SegmentRecordModalProps> = ({
         backgroundColor="white"
         padding={0}
         centerY={centerY}
+        sideTooltip={sideTooltip}
       >
         {/* 콘텐츠 영역 */}
         <View

--- a/src/components/counter/SegmentRecordModal.tsx
+++ b/src/components/counter/SegmentRecordModal.tsx
@@ -6,7 +6,54 @@ import { SectionRecord } from '@storage/types';
 import { getEditContentText } from '@utils/sectionRecordUtils';
 import CircleIcon from '@components/common/CircleIcon';
 import RecordListModal from './RecordListModal';
+import Tooltip from '@components/common/Tooltip';
 import { Mic } from 'lucide-react-native';
+
+/**
+ * SlideModal과 같은 부모 아래 형제로 둠. 패널(열린 상태, 왼쪽 정렬) 박스 밖·상단 Y에 툴팁을 붙임.
+ * 패널 밖 배치를 위해 오버레이로 처리.
+ */
+const SegmentRecordAbovePanelTooltipOverlay: React.FC<{
+  panelWidth: number;
+  panelHeight: number;
+  centerYPx: number;
+  children: React.ReactNode;
+}> = ({ panelWidth, panelHeight, centerYPx, children }) => {
+  const gapPx = 8;
+  const modalTopPx = centerYPx - panelHeight / 2;
+  if (modalTopPx <= gapPx) {
+    return null;
+  }
+  return (
+    <View
+      pointerEvents="none"
+      className="absolute top-0 left-0 right-0 bottom-0"
+      style={{ zIndex: 52 }}
+    >
+      <View
+        style={{
+          position: 'absolute',
+          left: 0,
+          width: panelWidth,
+          top: 0,
+          height: modalTopPx - gapPx,
+          alignItems: 'center',
+        }}
+      >
+        <View
+          style={{
+            flex: 1,
+            width: '100%',
+            justifyContent: 'flex-end',
+            alignItems: 'center',
+          }}
+        >
+          {children}
+        </View>
+      </View>
+    </View>
+  );
+};
 
 // ===== 타입 정의 =====
 interface SegmentRecordModalProps {
@@ -21,6 +68,8 @@ interface SegmentRecordModalProps {
   sectionRecords?: SectionRecord[];
   /** SlideModal 패널 오른쪽에 표시 */
   sideTooltip?: React.ReactNode;
+  /** 툴팁 설정 on일 때, 모달 패널 밖(상단 Y) 안내(4초). 기록이 있을 때만 */
+  inlineRecordTooltipEnabled?: boolean;
 }
 
 // ===== 메인 컴포넌트 =====
@@ -35,6 +84,7 @@ export const SegmentRecordModal: React.FC<SegmentRecordModalProps> = ({
   centerY,
   sectionRecords = [],
   sideTooltip,
+  inlineRecordTooltipEnabled = false,
 }) => {
   const [showAllRecordsModal, setShowAllRecordsModal] = useState(false);
 
@@ -122,6 +172,19 @@ export const SegmentRecordModal: React.FC<SegmentRecordModalProps> = ({
           )}
         </View>
       </SlideModal>
+
+      {isOpen &&
+      inlineRecordTooltipEnabled &&
+      sectionRecords.length > 0 &&
+      typeof centerY === 'number' ? (
+        <SegmentRecordAbovePanelTooltipOverlay
+          panelWidth={width}
+          panelHeight={height}
+          centerYPx={centerY}
+        >
+          <Tooltip placement="bottom" text="터치하여 기록 더보기" />
+        </SegmentRecordAbovePanelTooltipOverlay>
+      ) : null}
 
       <RecordListModal
         visible={showAllRecordsModal}

--- a/src/components/counter/SubCounterModal.tsx
+++ b/src/components/counter/SubCounterModal.tsx
@@ -26,6 +26,8 @@ interface SubCounterModalProps {
   width: number;
   height: number;
   centerY: DimensionValue;
+  /** SlideModal 패널 오른쪽에 표시 */
+  sideTooltip?: React.ReactNode;
 }
 
 // ===== 메인 컴포넌트 =====
@@ -48,6 +50,7 @@ export const SubCounterModal: React.FC<SubCounterModalProps> = ({
   width,
   height,
   centerY,
+  sideTooltip,
 }) => {
   // 아이콘 크기 및 간격 정보
   const iconSize = getSubIconSize(screenSize);
@@ -62,6 +65,7 @@ export const SubCounterModal: React.FC<SubCounterModalProps> = ({
       backgroundColor="white"
       padding={0}
       centerY={centerY}
+      sideTooltip={sideTooltip}
     >
       {/* 터치 영역 - 배경 100% 차지 */}
       <SubCounterTouchArea

--- a/src/screens/CounterDetail.tsx
+++ b/src/screens/CounterDetail.tsx
@@ -210,6 +210,7 @@ const CounterDetail = () => {
     screenSize === ScreenSize.LARGE && effectiveVoiceCommandsActive;
   const { directionSectionFlex, voiceBannerSectionFlex, countSectionFlex, actionsSectionFlex } =
     getContentSectionFlexes(mascotIsActive, showCounterActions, showVoiceBanner);
+  const showSlideModalSideTooltips = tooltipEnabled && screenSize !== ScreenSize.COMPACT;
   const { timerHeightPx, gapBetweenTimerAndContentPx, contentHeightPx, bottomReservedHeightPx } =
     getCounterDetailVerticalPx({
       contentAreaHeight,
@@ -551,6 +552,15 @@ const CounterDetail = () => {
           height={segmentModalHeight}
           centerY={segmentModalCenterY}
           sectionRecords={counter.sectionRecords}
+          sideTooltip={
+            showSlideModalSideTooltips ? (
+              <Tooltip
+                placement="left"
+                text="활동 기록 보기"
+                visuallyHidden={!!(counter.sectionModalIsOpen ?? false)}
+              />
+            ) : undefined
+          }
         />
       )}
 
@@ -575,6 +585,15 @@ const CounterDetail = () => {
           width={subModalWidth}
           height={subModalHeight}
           centerY={subModalCenterY}
+          sideTooltip={
+            showSlideModalSideTooltips ? (
+              <Tooltip
+                placement="left"
+                text="보조 카운터 사용하기"
+                visuallyHidden={subModalIsOpen}
+              />
+            ) : undefined
+          }
         />
       )}
 

--- a/src/screens/CounterDetail.tsx
+++ b/src/screens/CounterDetail.tsx
@@ -552,6 +552,7 @@ const CounterDetail = () => {
           height={segmentModalHeight}
           centerY={segmentModalCenterY}
           sectionRecords={counter.sectionRecords}
+          inlineRecordTooltipEnabled={showSlideModalSideTooltips}
           sideTooltip={
             showSlideModalSideTooltips ? (
               <Tooltip


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #68 


## 🛠 작업 내용
<p float="left">
<img width="48%" alt="image" src="https://github.com/user-attachments/assets/754ce641-e0f3-4cc4-b77a-ed37dedf85a6" />
<img width="48%" alt="image" src="https://github.com/user-attachments/assets/b0634abd-056f-45ad-aaa2-6eefc830cc5c" />
</p>

- 기존 툴팁 삼각형과 네모 사이의 틈새 제거
- 툴팁을 강조하고자 불투명도 100%로 디자인 수정
- 카운터 진입 후 1회 슬라이드 모달이 닫힌 상태일 때 "활동 기록 보기", "보조 카운터 사용하기" 툴팁 적용
- 활동 기록 모달이 열린 상태일 때 "터치하여 기록 더보기" 툴팁 적용

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)

- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 시스템 폰트 사이즈, 화면 크기 변화에 대응하는 걸 확인했습니다.
- [x] 동료 작업자에게 수정 사항을 공유했습니다. 