### PR TITLE
fix: 유사어 교정에 음성 인식 증감이 두 번 실행되는 문제

### DIFF
--- a/src/hooks/useVoiceCommands.ts
+++ b/src/hooks/useVoiceCommands.ts
@@ -153,6 +153,27 @@ function getWordAction(word: string): 'add' | 'subtract' | 'subAdd' | 'subSubtra
 }
 
 /**
+ * 같은 인덱스에서 STT가 "군지" → "건지"처럼 교정만 해도 접두어가 같다고 보기 위해,
+ * 키워드 동작별로 하나의 토큰으로 치환한다. (실제 콜백에는 원문 단어를 그대로 넘긴다.)
+ */
+function canonicalizeKeywordForTranscriptDiff(word: string): string {
+  const action = getWordAction(word);
+  if (action === 'add') {
+    return '\0__kw_add__';
+  }
+  if (action === 'subtract') {
+    return '\0__kw_subtract__';
+  }
+  if (action === 'subAdd') {
+    return '\0__kw_subadd__';
+  }
+  if (action === 'subSubtract') {
+    return '\0__kw_subsubtract__';
+  }
+  return word;
+}
+
+/**
  * 화면 포커스 중 음성으로 "증가" / "감소" 계열 명령을 인식해 콜백을 호출하는 훅.
  * 버튼 없이 계속 듣다가 키워드가 들리면 동작한다.
  */
@@ -210,9 +231,13 @@ export function useVoiceCommands(
 
     // STT 엔진은 같은 문장을 partial -> final로 반복 전달하므로,
     // 이전 transcript와 공통 prefix를 비교해 "새 단어"만 액션으로 변환한다.
+    // 같은 슬롯에서 "군지" → "건지"처럼 유사어 교정만 일어난 경우는
+    // 동작이 같은 키워드면 접두어 길이에 포함해 한 번만 실행되게 한다.
     const runActionsFromTranscript = (text: string) => {
       const nextWords = normalizeTranscriptWords(text);
-      const commonPrefixLength = getCommonPrefixLength(lastTranscriptWords, nextWords);
+      const prevCanonical = lastTranscriptWords.map(canonicalizeKeywordForTranscriptDiff);
+      const nextCanonical = nextWords.map(canonicalizeKeywordForTranscriptDiff);
+      const commonPrefixLength = getCommonPrefixLength(prevCanonical, nextCanonical);
       const newWords = nextWords.slice(commonPrefixLength);
 
       lastTranscriptWords = nextWords;


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #178 


## 🛠 작업 내용

- 기존 방식에서 같은 위치의 단어만 바뀌는 교정(예: 군지 → 건지)이 오면, 지금 쓰는 방식은 원문 단어 배열로만 접두어를 맞추었음.

이전: ["안녕", "군지"]
다음: ["안녕", "건지"]
두 번째 인덱스에서 "군지" !== "건지"라서 공통 접두어 길이가 1이 되고, slice(1) 결과로 '건지'가 새 단어로 잡혀 액션이 한 번 더 실행되었습니다.

- 접두어 비교만 할 때는, 키워드 집합에 속한 단어를 동작별로 같은 토큰으로 치환했습니다. 군지와 건지가 둘 다 add면 비교용 문자열이 같아져서, 교정만 있을 때는 “새 단어”가 0개가 됩니다.

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)

- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 시스템 폰트 사이즈, 화면 크기 변화에 대응하는 걸 확인했습니다.
- [x] 동료 작업자에게 수정 사항을 공유했습니다. 