### PR TITLE
fix: 음성 키워드가 한 번 발화에 두 번 실행되던 문제 해결

### DIFF
--- a/src/hooks/useVoiceCommands.ts
+++ b/src/hooks/useVoiceCommands.ts
@@ -7,7 +7,7 @@ import { ExpoSpeechRecognitionModule } from 'expo-speech-recognition';
 const LOCALE = 'ko-KR';
 const KEYWORDS_ADD = ['곤지', '군지', '건지', '본지'];
 const KEYWORDS_SUBTRACT = ['연지', '현지', '연기'];
-const KEYWORDS_SUB_ADD = ['홍실', '홍신', '동실', '통실', '봉실', '뽕실', '통신'];
+const KEYWORDS_SUB_ADD = ['홍실', '홍신', '동실', '통실', '봉실', '뽕실', '통신', '공실'];
 const KEYWORDS_SUB_SUBTRACT = ['청실', '청신', '창실', '정신', '정실'];
 const KEYWORD_SET_ADD = new Set(KEYWORDS_ADD);
 const KEYWORD_SET_SUBTRACT = new Set(KEYWORDS_SUBTRACT);
@@ -24,6 +24,8 @@ const IDLE_RECYCLE_MS = 30000;
 const IDLE_RESTART_DELAY_MS = 1500;
 // start() 호출 후 이 시간 안에 start 이벤트가 없으면 시작이 멈춘 것으로 보고 abort()한다.
 const START_WATCHDOG_MS = 5000;
+// 세션 경계·지연 final 등으로 같은 키워드가 짧은 간격에 두 번 오는 경우 1회만 실행한다.
+const KEYWORD_ACTION_DEDUP_MS = 400;
 export const VOICE_LISTENING_TEXT = '듣는 중...';
 const MODEL_NOT_DOWNLOADED_MESSAGE_FRAGMENT =
   'requested language is supported, but not yet downloaded';
@@ -119,6 +121,11 @@ function normalizeTranscriptWords(text: string): string[] {
     .split(/\s+/)
     .map((word) => word.trim())
     .filter(Boolean);
+}
+
+/** STT가 같은 토큰을 연속으로 넣을 때 1번만 남긴다(배너·newWords 처리용). */
+function collapseConsecutiveDuplicateWords(words: string[]): string[] {
+  return words.filter((w, i) => i === 0 || w !== words[i - 1]);
 }
 
 function getCommonPrefixLength(previousWords: string[], nextWords: string[]): number {
@@ -222,11 +229,30 @@ export function useVoiceCommands(
     let nextRestartDelayMs = DEFAULT_RESTART_DELAY_MS;
     let lastActivityAt = Date.now();
     let isWaitingForOfflineModelDownload = false;
-    // partial/final result가 같은 prefix를 반복 전달하므로, 새로 들어온 단어만 액션으로 소비한다.
+    // partial/final이 같은 접두어를 반복하면 새 단어만 액션으로 소비한다.
+    // 리셋 타이밍은 아래 'start' 리스너를 본다(end에서 비우면 지연 final이 같은 말을 두 번 실행할 수 있다).
     let lastTranscriptWords: string[] = [];
+    let lastKeywordDedupKey = '';
+    let lastKeywordDedupAt = 0;
 
     const resetTranscriptTracking = () => {
       lastTranscriptWords = [];
+    };
+
+    const resetKeywordDedup = () => {
+      lastKeywordDedupKey = '';
+      lastKeywordDedupAt = 0;
+    };
+
+    const shouldSkipDuplicateKeywordAction = (action: string, word: string): boolean => {
+      const key = `${action}:${word}`;
+      const now = Date.now();
+      if (key === lastKeywordDedupKey && now - lastKeywordDedupAt < KEYWORD_ACTION_DEDUP_MS) {
+        return true;
+      }
+      lastKeywordDedupKey = key;
+      lastKeywordDedupAt = now;
+      return false;
     };
 
     // STT 엔진은 같은 문장을 partial -> final로 반복 전달하므로,
@@ -238,28 +264,48 @@ export function useVoiceCommands(
       const prevCanonical = lastTranscriptWords.map(canonicalizeKeywordForTranscriptDiff);
       const nextCanonical = nextWords.map(canonicalizeKeywordForTranscriptDiff);
       const commonPrefixLength = getCommonPrefixLength(prevCanonical, nextCanonical);
-      const newWords = nextWords.slice(commonPrefixLength);
+      let newWords = nextWords.slice(commonPrefixLength);
+
+      const prevTail = lastTranscriptWords[lastTranscriptWords.length - 1];
+      if (
+        prevTail !== undefined &&
+        newWords.length > 0 &&
+        newWords.every((w) => w === prevTail)
+      ) {
+        lastTranscriptWords = nextWords;
+        return;
+      }
+
+      newWords = collapseConsecutiveDuplicateWords(newWords);
 
       lastTranscriptWords = nextWords;
       newWords.forEach((word) => {
         const action = getWordAction(word);
         if (action === 'add') {
-          onAddRef.current(word);
+          if (!shouldSkipDuplicateKeywordAction(action, word)) {
+            onAddRef.current(word);
+          }
           return;
         }
 
         if (action === 'subtract') {
-          onSubtractRef.current(word);
+          if (!shouldSkipDuplicateKeywordAction(action, word)) {
+            onSubtractRef.current(word);
+          }
           return;
         }
 
         if (action === 'subAdd') {
-          onSubAddRef.current?.(word);
+          if (!shouldSkipDuplicateKeywordAction(action, word)) {
+            onSubAddRef.current?.(word);
+          }
           return;
         }
 
         if (action === 'subSubtract') {
-          onSubSubtractRef.current?.(word);
+          if (!shouldSkipDuplicateKeywordAction(action, word)) {
+            onSubSubtractRef.current?.(word);
+          }
         }
       });
     };
@@ -413,7 +459,6 @@ export function useVoiceCommands(
       }
 
       isStarting = true;
-      resetTranscriptTracking();
       clearAllTimeouts();
       onErrorRef.current?.('');
       onRecognizedRef.current?.('마이크 준비 중...');
@@ -504,6 +549,8 @@ export function useVoiceCommands(
         isStarting = false;
         isRecognizing = true;
         clearStartWatchdog();
+        resetTranscriptTracking();
+        resetKeywordDedup();
         onErrorRef.current?.('');
         onRecognizedRef.current?.(VOICE_LISTENING_TEXT);
         touchActivity('start');
@@ -533,11 +580,12 @@ export function useVoiceCommands(
         clearStartWatchdog();
         const transcript = event.results[0]?.transcript ?? '';
         if (transcript) {
-          // partial/final 결과 모두 배너 표시에는 전달하되,
-          // 실제 add/subtract 액션은 runActionsFromTranscript가 중복을 걸러낸다.
           touchActivity(event.isFinal ? 'result-final' : 'result-partial');
-          onRecognizedRef.current?.(transcript);
           onErrorRef.current?.('');
+          const forDisplay = collapseConsecutiveDuplicateWords(
+            normalizeTranscriptWords(transcript)
+          ).join(' ');
+          onRecognizedRef.current?.(forDisplay);
           runActionsFromTranscript(transcript);
         }
       }
@@ -625,8 +673,7 @@ export function useVoiceCommands(
       () => {
         clearStartWatchdog();
         clearIdleRecycleTimeout();
-        // 세션 경계가 바뀌면 transcript diff 기준도 함께 리셋한다.
-        resetTranscriptTracking();
+        // transcript는 'start'에서만 리셋한다. 여기서 비우면 partial 직후 end·지연 final 조합에서 같은 말이 두 번 실행된다.
         isStarting = false;
         isRecognizing = false;
 
@@ -652,6 +699,7 @@ export function useVoiceCommands(
       cancelled = true;
       ignoreNextAbortedError = true;
       resetTranscriptTracking();
+      resetKeywordDedup();
       clearAllTimeouts();
       // unmount/disable 시에는 현재 세션을 중단시키고,
       // 뒤따라오는 aborted 에러는 ignoreNextAbortedError로 무시한다.


### PR DESCRIPTION

## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #184 


## 🛠 작업 내용


원인
- 음성 인식은 partial과 final이 같은 접두어로 여러 번 오는 경우가 있어, lastTranscriptWords와의 공통 접두어 diff만으로는 대부분 중복 실행을 막을 수 있었습니다.
- 그런데 end 핸들러에서 resetTranscriptTracking()을 호출하면, 이미 partial로 처리된 뒤 늦게 도착한 final이 빈 상태와 비교되어 같은 키워드가 다시 “새 단어”로 처리될 수 있었습니다.
- startListening 진입 시점에 transcript를 비우던 타이밍도, 재시작 직전·직후에 오는 결과와 겹치면 같은 유형의 이중 실행을 키울 수 있었습니다.
- 일부 STT/연속 인식 경로에서는 누적 문자열 끝에 동일 토큰이 한 번 더 붙는 형태(… 연지 → 연지 연지)가 나와, 접두어 길이만 보면 **추가 접미사가 “새 단어”**로 남는 경우가 있었습니다.

결과
- end에서는 transcript 추적을 리셋하지 않고, 네이티브 start 이벤트에서만 lastTranscriptWords를 초기화해 세션 경계와 지연 결과의 순서가 어긋날 때의 중복 실행을 줄였습니다.
- startListening 시작 시 하던 transcript 리셋은 제거해, 위와 같은 리셋·결과 경쟁을 완화했습니다.
- 누적 결과에서 **이전 마지막 단어와만 이루어진 접미 newWords**는 액션 없이 상태만 반영하고, newWords 내부 연속 중복 토큰은 한 번만 실행되도록 정리했습니다.
- 배너용 문구는 연속 중복 토큰을 접은 문자열로 넘겨, 한 번 말했을 때 연지 연지처럼 보이는 노이즈를 줄였습니다.
- 남는 엣지 케이스를 위해 동일 키워드(동작+단어)에 대한 짧은 구간 디바운스(KEYWORD_ACTION_DEDUP_MS)를 두어, 같은 발화에 대한 이중 증감 가능성을 추가로 낮췄습니다.

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)

- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 시스템 폰트 사이즈, 화면 크기 변화에 대응하는 걸 확인했습니다.
- [x] 동료 작업자에게 수정 사항을 공유했습니다. 