### PR TITLE
design: 말풍선 교체 애니메이션 추가

### DIFF
--- a/src/components/counter/CounterDirection.tsx
+++ b/src/components/counter/CounterDirection.tsx
@@ -1,7 +1,7 @@
 // src/components/counter/CounterDirection.tsx
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { View, Image, Pressable, Text } from 'react-native';
-import Animated, { FadeIn, Keyframe, LinearTransition } from 'react-native-reanimated';
+import Animated, { Keyframe, LinearTransition } from 'react-native-reanimated';
 import { Way, RepeatRule } from '@storage/types';
 import { directionImages } from '@assets/images';
 import EmphasisBubbleIcon from '@assets/images/way/emphasis_bubble.svg';
@@ -33,6 +33,9 @@ const TEXT_CONTAINER_WIDTH_RATIO = 0.6; // 텍스트 컨테이너의 너비 비�
 // 규칙 순회 간격
 const RULE_ROTATION_INTERVAL_MS = 2000; // 규칙 순회 간격 (밀리초)
 const DIRECTION_VERTICAL_OFFSET_RATIO = 0.18; // 방향 컴포넌트 세로 오프셋 (이미지 높이 비율)
+const DISAPPEARING_BUBBLE_ANIMATION_DURATION_MS = 260; // 사라지는 말풍선 애니메이션 길이
+const FLOATING_THIRD_BUBBLE_ANIMATION_DURATION_MS = 460; // 마지막 말풍선 떠오름 애니메이션 길이
+const STACK_LAYOUT_TRANSITION_DURATION_MS = 280; // 중간 말풍선 위치 전환 애니메이션 길이
 
 const BUBBLE_BASE_LEFT_RATIO = 0.05 + 0.5 - BUBBLE_SIZE_SCALE / 2;
 const TEXT_CONTAINER_IN_BUBBLE_LEFT_RATIO =
@@ -87,10 +90,15 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
     }))
   );
 
-  // 여러 규칙이 있을 때 순회를 위한 상태
-  const [currentRuleIndex, setCurrentRuleIndex] = useState(0);
+  /**
+   * 여러 규칙이 있을 때 순회를 위한 상태 (단조증가 카운터)
+   * - `% rulesLength`로 나눈 값이 실제 표시 인덱스이지만,
+   *   내부적으로는 절대 리셋되지 않는 단조증가 값으로 관리한다.
+   * - 이렇게 해야 말풍선 key에 섞는 "도착 시점"이 순환/리셋으로 인해
+   *   충돌(같은 규칙의 서로 다른 인스턴스가 동일 key를 갖는 문제)하지 않는다.
+   */
+  const [rotationCount, setRotationCount] = useState(0);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const previousVisibleRuleKeysRef = useRef<string[]>([]);
   const hasMountedStackRef = useRef(false);
 
   /**
@@ -99,7 +107,7 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
    * - 같은 단이라도 규칙 편집으로 인해 적용 규칙 목록이 달라졌을 때
    */
   useEffect(() => {
-    setCurrentRuleIndex(0);
+    setRotationCount(0);
   }, [currentCount, appliedRulesKey]);
 
   /**
@@ -113,9 +121,8 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
     }
 
     if (appliedRules.length > 1) {
-      const rulesLength = appliedRules.length;
       intervalRef.current = setInterval(() => {
-        setCurrentRuleIndex((prevIndex) => (prevIndex + 1) % rulesLength);
+        setRotationCount((prevCount) => prevCount + 1);
       }, RULE_ROTATION_INTERVAL_MS);
     }
 
@@ -127,31 +134,36 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
     };
   }, [appliedRulesKey, appliedRules.length]);
 
-  // 현재 규칙부터 뒤쪽 규칙까지 최대 3개를 스택으로 표시
+  /**
+   * 현재 규칙부터 뒤쪽 규칙까지 최대 3개를 스택으로 표시
+   * - stackIndex 0 = 맨 앞(현재 표시 중인 말풍선)
+   * - stackIndex visibleCount-1 = 스택의 꼬리(가장 뒤, 가장 위쪽)
+   * - arrivalTime = 해당 말풍선이 처음 꼬리에 도착했던 시점의 rotationCount (단조증가)
+   *   - 같은 규칙이 순환 중 반복적으로 등장할 때, 서로 다른 "인스턴스"로 구분하기 위한 키 요소
+   *   - 2~3개 규칙에서도 퇴장/진입이 실제 mount/unmount로 일어나게 해서 애니메이션이 자연스럽게 적용됨
+   */
   const visibleRules = useMemo(() => {
     if (appliedRules.length === 0) {
       return [];
     }
 
-    const visibleCount = Math.min(MAX_VISIBLE_RULE_BUBBLES, appliedRules.length);
-    return Array.from({ length: visibleCount }, (_, stackIndex) => ({
-      stackIndex,
-      rule: appliedRules[(currentRuleIndex + stackIndex) % appliedRules.length],
-    }));
-  }, [appliedRules, currentRuleIndex]);
+    const rulesLength = appliedRules.length;
+    const visibleCount = Math.min(MAX_VISIBLE_RULE_BUBBLES, rulesLength);
+    return Array.from({ length: visibleCount }, (_, stackIndex) => {
+      const rule = appliedRules[(rotationCount + stackIndex) % rulesLength];
+      const arrivalTime = rotationCount - (visibleCount - 1 - stackIndex);
+      return {
+        stackIndex,
+        rule,
+        bubbleKey: `${buildRuleKey(rule)}@${arrivalTime}`,
+      };
+    });
+  }, [appliedRules, rotationCount]);
 
   const currentRule = visibleRules[0]?.rule;
-  const visibleRuleKeys = visibleRules.map(({ rule }) => buildRuleKey(rule));
-  const movedToBackRuleKey =
-    previousVisibleRuleKeysRef.current.length === visibleRuleKeys.length &&
-    previousVisibleRuleKeysRef.current[0] === visibleRuleKeys[visibleRuleKeys.length - 1] &&
-    previousVisibleRuleKeysRef.current.slice(1).every((key, index) => key === visibleRuleKeys[index])
-      ? visibleRuleKeys[visibleRuleKeys.length - 1]
-      : null;
-
-  useEffect(() => {
-    previousVisibleRuleKeysRef.current = visibleRuleKeys;
-  }, [visibleRuleKeys]);
+  // 사용자에게 보여줄 1-based 인덱스는 순환값 사용
+  const displayRuleIndex =
+    appliedRules.length > 0 ? (rotationCount % appliedRules.length) + 1 : 0;
 
   useEffect(() => {
     hasMountedStackRef.current = true;
@@ -164,6 +176,7 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
     }
     return calculateInitialFontSize(currentRule.message.length, imageWidth, imageHeight);
   }, [currentRule?.message, imageHeight, imageWidth]);
+
   const disappearingBubbleExitAnimation = useMemo(
     () =>
       new Keyframe({
@@ -175,7 +188,7 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
           opacity: 0,
           transform: [{ translateY: imageHeight * 0.22 }, { scale: 1.18 }],
         },
-      }).duration(260),
+      }).duration(DISAPPEARING_BUBBLE_ANIMATION_DURATION_MS),
     [imageHeight]
   );
   const disappearingBubbleGhostExitAnimation = useMemo(
@@ -189,7 +202,7 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
           opacity: 0,
           transform: [{ translateY: imageHeight * 0.1 }, { scale: 1.28 }],
         },
-      }).duration(260),
+      }).duration(DISAPPEARING_BUBBLE_ANIMATION_DURATION_MS),
     [imageHeight]
   );
   const floatingThirdBubbleEnterAnimation = useMemo(
@@ -207,7 +220,7 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
           opacity: 1,
           transform: [{ translateY: 0 }, { scale: 1 }],
         },
-      }).duration(460),
+      }).duration(FLOATING_THIRD_BUBBLE_ANIMATION_DURATION_MS),
     [imageHeight]
   );
 
@@ -232,6 +245,11 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
       imageSource = directionImages.way_plain;
     }
   }
+
+  const bubbleBaseWidth = imageWidth * BUBBLE_SIZE_SCALE;
+  const bubbleBaseHeight = imageHeight * BUBBLE_SIZE_SCALE;
+  const bubbleBaseLeft = imageWidth * BUBBLE_BASE_LEFT_RATIO;
+  const bubbleBaseTop = imageHeight * -0.8;
 
   return (
     <View style={{ height: imageHeight }}>
@@ -259,7 +277,7 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
                   pointerEvents="none"
                 >
                   <Text className="text-sm text-darkgray text-center font-bold">
-                    {currentRuleIndex + 1}/{appliedRules.length}
+                    {displayRuleIndex}/{appliedRules.length}
                   </Text>
                 </View>
               )}
@@ -267,46 +285,28 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
               {visibleRules
                 .slice()
                 .reverse()
-                .map(({ stackIndex, rule }) => {
-                  const ruleKey = buildRuleKey(rule);
-                  const bubbleBaseWidth = imageWidth * BUBBLE_SIZE_SCALE;
-                  const bubbleBaseHeight = imageHeight * BUBBLE_SIZE_SCALE;
-                  const bubbleBaseLeft = imageWidth * BUBBLE_BASE_LEFT_RATIO;
-                  const bubbleBaseTop = imageHeight * -0.8;
+                .map(({ stackIndex, rule, bubbleKey }) => {
                   const scale = 1 - STACK_SCALE_STEP * stackIndex;
                   const bubbleTop = bubbleBaseTop - imageHeight * STACK_VERTICAL_GAP_RATIO * stackIndex;
                   const bubbleLeft = bubbleBaseLeft;
                   const isCurrentBubble = stackIndex === 0;
-                  const shouldSkipLayoutAnimation =
-                    movedToBackRuleKey === ruleKey && stackIndex === visibleRules.length - 1;
-                  const shouldAnimateEnterExit = hasMountedStackRef.current && !preferReducedMotion;
-                  const shouldUseDisappearingExitAnimation =
-                    shouldAnimateEnterExit && movedToBackRuleKey !== ruleKey;
-                  const shouldUseFloatingThirdBubbleEnterAnimation =
-                    shouldAnimateEnterExit && stackIndex === MAX_VISIBLE_RULE_BUBBLES - 1;
+                  const shouldAnimate = hasMountedStackRef.current && !preferReducedMotion;
+                  // 꼬리(가장 뒤)에서 새로 들어오는 말풍선은 떠오름 애니메이션
+                  // - 2개 규칙에서는 꼬리가 stackIndex 1이므로 이 조건에 걸리지 않아 그냥 등장
+                  // - 3개 이상에서는 꼬리가 stackIndex 2이므로 떠오름 애니메이션 적용
+                  const shouldUseFloatingEnter =
+                    shouldAnimate && stackIndex === MAX_VISIBLE_RULE_BUBBLES - 1;
 
                   return (
                     <Animated.View
-                      key={ruleKey}
+                      key={bubbleKey}
                       layout={
-                        preferReducedMotion || shouldSkipLayoutAnimation
+                        preferReducedMotion
                           ? undefined
-                          : LinearTransition.duration(280)
+                          : LinearTransition.duration(STACK_LAYOUT_TRANSITION_DURATION_MS)
                       }
-                      entering={
-                        shouldUseFloatingThirdBubbleEnterAnimation
-                          ? floatingThirdBubbleEnterAnimation
-                          : shouldAnimateEnterExit
-                          ? FadeIn.duration(180).withInitialValues({
-                              opacity: 0,
-                            })
-                          : undefined
-                      }
-                      exiting={
-                        shouldUseDisappearingExitAnimation
-                          ? disappearingBubbleExitAnimation
-                          : undefined
-                      }
+                      entering={shouldUseFloatingEnter ? floatingThirdBubbleEnterAnimation : undefined}
+                      exiting={shouldAnimate ? disappearingBubbleExitAnimation : undefined}
                       pointerEvents="none"
                       style={{
                         position: 'absolute',
@@ -317,13 +317,10 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
                         zIndex: 1,
                       }}
                     >
+                      {/* 퇴장 시에만 잠깐 보이는 블러 잔상 레이어 (평상시 opacity 0) */}
                       <Animated.View
                         pointerEvents="none"
-                        exiting={
-                          shouldUseDisappearingExitAnimation
-                            ? disappearingBubbleGhostExitAnimation
-                            : undefined
-                        }
+                        exiting={shouldAnimate ? disappearingBubbleGhostExitAnimation : undefined}
                         style={{
                           position: 'absolute',
                           top: 0,
@@ -339,7 +336,7 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
 
                           return (
                             <View
-                              key={`${ruleKey}-ghost-${layerIndex}`}
+                              key={`${bubbleKey}-ghost-${layerIndex}`}
                               pointerEvents="none"
                               style={{
                                 position: 'absolute',

--- a/src/components/counter/CounterDirection.tsx
+++ b/src/components/counter/CounterDirection.tsx
@@ -25,10 +25,15 @@ const BUBBLE_SIZE_SCALE = 1.15; // 버블 이미지 크기 배율
 const MAX_VISIBLE_RULE_BUBBLES = 3; // 현재 포함 최대 3개의 말풍선만 노출
 const STACK_VERTICAL_GAP_RATIO = 0.14; // 말풍선 스택 간 세로 간격
 const STACK_SCALE_STEP = 0.12; // 뒤쪽 말풍선 축소 비율
+const BUBBLE_STACK_TOP_RATIO = -0.8; // 스택 맨 앞(stackIndex=0) 말풍선의 세로 위치 (이미지 높이 비율)
 
 // 텍스트 컨테이너 위치 상수
 const TEXT_CONTAINER_LEFT_RATIO = 0.2; // 텍스트 컨테이너의 좌측 오프셋 비율 (이미지 너비 대비)
 const TEXT_CONTAINER_WIDTH_RATIO = 0.6; // 텍스트 컨테이너의 너비 비율 (이미지 너비 대비)
+const DEFAULT_TEXT_FONT_SIZE_RATIO = 0.3; // 메시지가 없을 때 사용할 기본 폰트 크기 (이미지 높이 비율)
+
+// 다중 규칙 라벨 위치 (말풍선 스택 위쪽에 분리 표시)
+const MULTI_RULE_LABEL_BASE_TOP_RATIO = -1.3;
 
 // 규칙 순회 간격
 const RULE_ROTATION_INTERVAL_MS = 2000; // 규칙 순회 간격 (밀리초)
@@ -42,6 +47,26 @@ const TEXT_CONTAINER_IN_BUBBLE_LEFT_RATIO =
   (TEXT_CONTAINER_LEFT_RATIO - BUBBLE_BASE_LEFT_RATIO) / BUBBLE_SIZE_SCALE;
 const TEXT_CONTAINER_IN_BUBBLE_WIDTH_RATIO = TEXT_CONTAINER_WIDTH_RATIO / BUBBLE_SIZE_SCALE;
 
+/**
+ * 퇴장 시 재생되는 블러 잔상 레이어 구성
+ * - 본체가 블러로 사라질 때 살짝 뒤로 번지는 잔상 효과를 내기 위해
+ *   크기·투명도·세로 오프셋을 조금씩 다르게 한 복제 레이어를 겹쳐서 렌더링한다.
+ */
+const DISAPPEARING_GHOST_LAYERS: ReadonlyArray<{
+  opacity: number;
+  scale: number;
+  verticalOffsetRatio: number;
+}> = [
+  { opacity: 0.16, scale: 1.05, verticalOffsetRatio: 0 },
+  { opacity: 0.1, scale: 1.12, verticalOffsetRatio: 0.015 },
+  { opacity: 0.06, scale: 1.19, verticalOffsetRatio: 0.03 },
+];
+
+/**
+ * 규칙 고유 key 생성 함수
+ * - 동일 규칙인지 판별할 때 사용
+ * - 스택 내 렌더링 key는 여기에 "도착 시점"을 덧붙여 중복을 방지한다 (visibleRules 참고)
+ */
 const buildRuleKey = (rule: RepeatRule) =>
   [
     rule.ruleNumber,
@@ -51,6 +76,26 @@ const buildRuleKey = (rule: RepeatRule) =>
     rule.message,
     rule.color,
   ].join(':');
+
+/**
+ * 현재 단의 규칙 적용 여부와 방향 토글 가능 여부에 따라 마스코트 방향 이미지를 선택한다.
+ */
+const resolveDirectionImage = (
+  isRuleAppliedToCurrentCount: boolean,
+  wayIsChange: boolean,
+  way: Way,
+) => {
+  if (isRuleAppliedToCurrentCount) {
+    if (!wayIsChange) {
+      return directionImages.emphasis_plain;
+    }
+    return way === 'front' ? directionImages.emphasis_front : directionImages.emphasis_back;
+  }
+  if (!wayIsChange) {
+    return directionImages.way_plain;
+  }
+  return way === 'front' ? directionImages.way_front : directionImages.way_back;
+};
 
 /**
  * 카운터 방향 표시 컴포넌트
@@ -172,7 +217,7 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
   // 텍스트 길이에 따라 폰트 크기를 미리 계산
   const textFontSize = useMemo(() => {
     if (!currentRule?.message) {
-      return imageHeight * 0.3;
+      return imageHeight * DEFAULT_TEXT_FONT_SIZE_RATIO;
     }
     return calculateInitialFontSize(currentRule.message.length, imageWidth, imageHeight);
   }, [currentRule?.message, imageHeight, imageWidth]);
@@ -228,28 +273,13 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
     return null;
   }
 
-  // 이미지 선택 로직
-  let imageSource;
-  if (isRuleAppliedToCurrentCount) {
-    // 규칙이 적용되는 단: emphasis 이미지 사용
-    if (wayIsChange) {
-      imageSource = way === 'front' ? directionImages.emphasis_front : directionImages.emphasis_back;
-    } else {
-      imageSource = directionImages.emphasis_plain;
-    }
-  } else {
-    // 규칙이 적용되지 않는 단: 기존 이미지 사용
-    if (wayIsChange) {
-      imageSource = way === 'front' ? directionImages.way_front : directionImages.way_back;
-    } else {
-      imageSource = directionImages.way_plain;
-    }
-  }
+  // 현재 단의 규칙 적용 여부와 방향 토글 가능 여부에 따라 마스코트 이미지 선택
+  const imageSource = resolveDirectionImage(isRuleAppliedToCurrentCount, wayIsChange, way);
 
   const bubbleBaseWidth = imageWidth * BUBBLE_SIZE_SCALE;
   const bubbleBaseHeight = imageHeight * BUBBLE_SIZE_SCALE;
   const bubbleBaseLeft = imageWidth * BUBBLE_BASE_LEFT_RATIO;
-  const bubbleBaseTop = imageHeight * -0.8;
+  const bubbleBaseTop = imageHeight * BUBBLE_STACK_TOP_RATIO;
 
   return (
     <View style={{ height: imageHeight }}>
@@ -271,7 +301,8 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
                   style={{
                     top:
                       imageHeight *
-                      (-1.3 - STACK_VERTICAL_GAP_RATIO * Math.max(0, visibleRules.length - 2)),
+                      (MULTI_RULE_LABEL_BASE_TOP_RATIO -
+                        STACK_VERTICAL_GAP_RATIO * Math.max(0, visibleRules.length - 2)),
                     zIndex: 1,
                   }}
                   pointerEvents="none"
@@ -288,12 +319,13 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
                 .map(({ stackIndex, rule, bubbleKey }) => {
                   const scale = 1 - STACK_SCALE_STEP * stackIndex;
                   const bubbleTop = bubbleBaseTop - imageHeight * STACK_VERTICAL_GAP_RATIO * stackIndex;
-                  const bubbleLeft = bubbleBaseLeft;
                   const isCurrentBubble = stackIndex === 0;
                   const shouldAnimate = hasMountedStackRef.current && !preferReducedMotion;
-                  // 꼬리(가장 뒤)에서 새로 들어오는 말풍선은 떠오름 애니메이션
-                  // - 2개 규칙에서는 꼬리가 stackIndex 1이므로 이 조건에 걸리지 않아 그냥 등장
-                  // - 3개 이상에서는 꼬리가 stackIndex 2이므로 떠오름 애니메이션 적용
+                  /**
+                   * 꼬리(가장 뒤)에서 새로 들어오는 말풍선은 떠오름 애니메이션을 적용
+                   * - 2개 규칙: 꼬리가 stackIndex 1이므로 이 조건에 걸리지 않아 그냥 등장
+                   * - 3개 이상: 꼬리가 stackIndex 2이므로 떠오름 애니메이션 적용
+                   */
                   const shouldUseFloatingEnter =
                     shouldAnimate && stackIndex === MAX_VISIBLE_RULE_BUBBLES - 1;
 
@@ -313,7 +345,7 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
                         width: bubbleBaseWidth,
                         height: bubbleBaseHeight,
                         top: bubbleTop,
-                        left: bubbleLeft,
+                        left: bubbleBaseLeft,
                         zIndex: 1,
                       }}
                     >
@@ -330,33 +362,29 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
                           opacity: 0,
                         }}
                       >
-                        {[0.16, 0.1, 0.06].map((layerOpacity, layerIndex) => {
-                          const ghostScale = 1.05 + layerIndex * 0.07;
-                          const ghostOffsetY = imageHeight * 0.015 * layerIndex;
-
-                          return (
-                            <View
-                              key={`${bubbleKey}-ghost-${layerIndex}`}
-                              pointerEvents="none"
-                              style={{
-                                position: 'absolute',
-                                top: ghostOffsetY,
-                                left: 0,
-                                width: bubbleBaseWidth,
-                                height: bubbleBaseHeight,
-                                opacity: layerOpacity,
-                                transform: [{ scale: ghostScale }],
-                              }}
-                            >
-                              <EmphasisBubbleIcon
-                                width={bubbleBaseWidth}
-                                height={bubbleBaseHeight}
-                                color={rule.color}
-                              />
-                            </View>
-                          );
-                        })}
+                        {DISAPPEARING_GHOST_LAYERS.map((layer, layerIndex) => (
+                          <View
+                            key={`${bubbleKey}-ghost-${layerIndex}`}
+                            pointerEvents="none"
+                            style={{
+                              position: 'absolute',
+                              top: imageHeight * layer.verticalOffsetRatio,
+                              left: 0,
+                              width: bubbleBaseWidth,
+                              height: bubbleBaseHeight,
+                              opacity: layer.opacity,
+                              transform: [{ scale: layer.scale }],
+                            }}
+                          >
+                            <EmphasisBubbleIcon
+                              width={bubbleBaseWidth}
+                              height={bubbleBaseHeight}
+                              color={rule.color}
+                            />
+                          </View>
+                        ))}
                       </Animated.View>
+                      {/* 본체 말풍선 아이콘 (스택 깊이에 따라 scale 적용) */}
                       <View
                         style={{
                           width: bubbleBaseWidth,
@@ -370,6 +398,7 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
                           color={rule.color}
                         />
                       </View>
+                      {/* 맨 앞 말풍선에만 규칙 메시지 텍스트 표시 */}
                       {isCurrentBubble && (
                         <View
                           style={{
@@ -382,7 +411,6 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
                             alignItems: 'center',
                           }}
                         >
-                          {/* 규칙 메시지 텍스트 */}
                           <Text
                             className="font-bold text-center"
                             style={{

--- a/src/components/counter/CounterDirection.tsx
+++ b/src/components/counter/CounterDirection.tsx
@@ -1,9 +1,11 @@
 // src/components/counter/CounterDirection.tsx
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { View, Image, Pressable, Text } from 'react-native';
+import Animated, { FadeIn, Keyframe, LinearTransition } from 'react-native-reanimated';
 import { Way, RepeatRule } from '@storage/types';
 import { directionImages } from '@assets/images';
 import EmphasisBubbleIcon from '@assets/images/way/emphasis_bubble.svg';
+import { usePreferReducedMotion } from '@hooks/usePreferReducedMotion';
 import { isRuleApplied, isDarkColor } from '@utils/ruleUtils';
 import { calculateInitialFontSize } from '@utils/textUtils';
 
@@ -20,6 +22,9 @@ interface CounterDirectionProps {
 
 // 버블 이미지 크기 상수
 const BUBBLE_SIZE_SCALE = 1.15; // 버블 이미지 크기 배율
+const MAX_VISIBLE_RULE_BUBBLES = 3; // 현재 포함 최대 3개의 말풍선만 노출
+const STACK_VERTICAL_GAP_RATIO = 0.14; // 말풍선 스택 간 세로 간격
+const STACK_SCALE_STEP = 0.12; // 뒤쪽 말풍선 축소 비율
 
 // 텍스트 컨테이너 위치 상수
 const TEXT_CONTAINER_LEFT_RATIO = 0.2; // 텍스트 컨테이너의 좌측 오프셋 비율 (이미지 너비 대비)
@@ -28,6 +33,21 @@ const TEXT_CONTAINER_WIDTH_RATIO = 0.6; // 텍스트 컨테이너의 너비 비�
 // 규칙 순회 간격
 const RULE_ROTATION_INTERVAL_MS = 2000; // 규칙 순회 간격 (밀리초)
 const DIRECTION_VERTICAL_OFFSET_RATIO = 0.18; // 방향 컴포넌트 세로 오프셋 (이미지 높이 비율)
+
+const BUBBLE_BASE_LEFT_RATIO = 0.05 + 0.5 - BUBBLE_SIZE_SCALE / 2;
+const TEXT_CONTAINER_IN_BUBBLE_LEFT_RATIO =
+  (TEXT_CONTAINER_LEFT_RATIO - BUBBLE_BASE_LEFT_RATIO) / BUBBLE_SIZE_SCALE;
+const TEXT_CONTAINER_IN_BUBBLE_WIDTH_RATIO = TEXT_CONTAINER_WIDTH_RATIO / BUBBLE_SIZE_SCALE;
+
+const buildRuleKey = (rule: RepeatRule) =>
+  [
+    rule.ruleNumber,
+    rule.startNumber ?? 'none',
+    rule.endNumber,
+    rule.repeatCount ?? 0,
+    rule.message,
+    rule.color,
+  ].join(':');
 
 /**
  * 카운터 방향 표시 컴포넌트
@@ -44,6 +64,7 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
   imageHeight,
   onToggleWay,
 }) => {
+  const preferReducedMotion = usePreferReducedMotion();
   /**
    * 현재 단수에 적용되는 규칙들
    * - 여러 규칙이 한 단에 동시에 적용될 수 있음
@@ -69,6 +90,8 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
   // 여러 규칙이 있을 때 순회를 위한 상태
   const [currentRuleIndex, setCurrentRuleIndex] = useState(0);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const previousVisibleRuleKeysRef = useRef<string[]>([]);
+  const hasMountedStackRef = useRef(false);
 
   /**
    * 적용 규칙이 바뀌면(또는 단수가 바뀌면) 표시 인덱스를 0으로 리셋
@@ -104,9 +127,35 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
     };
   }, [appliedRulesKey, appliedRules.length]);
 
-  // 현재 표시할 규칙 (안전하게 인덱스 보정)
-  const currentRule =
-    appliedRules.length > 0 ? appliedRules[currentRuleIndex % appliedRules.length] : undefined;
+  // 현재 규칙부터 뒤쪽 규칙까지 최대 3개를 스택으로 표시
+  const visibleRules = useMemo(() => {
+    if (appliedRules.length === 0) {
+      return [];
+    }
+
+    const visibleCount = Math.min(MAX_VISIBLE_RULE_BUBBLES, appliedRules.length);
+    return Array.from({ length: visibleCount }, (_, stackIndex) => ({
+      stackIndex,
+      rule: appliedRules[(currentRuleIndex + stackIndex) % appliedRules.length],
+    }));
+  }, [appliedRules, currentRuleIndex]);
+
+  const currentRule = visibleRules[0]?.rule;
+  const visibleRuleKeys = visibleRules.map(({ rule }) => buildRuleKey(rule));
+  const movedToBackRuleKey =
+    previousVisibleRuleKeysRef.current.length === visibleRuleKeys.length &&
+    previousVisibleRuleKeysRef.current[0] === visibleRuleKeys[visibleRuleKeys.length - 1] &&
+    previousVisibleRuleKeysRef.current.slice(1).every((key, index) => key === visibleRuleKeys[index])
+      ? visibleRuleKeys[visibleRuleKeys.length - 1]
+      : null;
+
+  useEffect(() => {
+    previousVisibleRuleKeysRef.current = visibleRuleKeys;
+  }, [visibleRuleKeys]);
+
+  useEffect(() => {
+    hasMountedStackRef.current = true;
+  }, []);
 
   // 텍스트 길이에 따라 폰트 크기를 미리 계산
   const textFontSize = useMemo(() => {
@@ -115,6 +164,52 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
     }
     return calculateInitialFontSize(currentRule.message.length, imageWidth, imageHeight);
   }, [currentRule?.message, imageHeight, imageWidth]);
+  const disappearingBubbleExitAnimation = useMemo(
+    () =>
+      new Keyframe({
+        0: {
+          opacity: 1,
+          transform: [{ translateY: 0 }, { scale: 1 }],
+        },
+        100: {
+          opacity: 0,
+          transform: [{ translateY: imageHeight * 0.22 }, { scale: 1.18 }],
+        },
+      }).duration(260),
+    [imageHeight]
+  );
+  const disappearingBubbleGhostExitAnimation = useMemo(
+    () =>
+      new Keyframe({
+        0: {
+          opacity: 0.22,
+          transform: [{ translateY: 0 }, { scale: 1.02 }],
+        },
+        100: {
+          opacity: 0,
+          transform: [{ translateY: imageHeight * 0.1 }, { scale: 1.28 }],
+        },
+      }).duration(260),
+    [imageHeight]
+  );
+  const floatingThirdBubbleEnterAnimation = useMemo(
+    () =>
+      new Keyframe({
+        0: {
+          opacity: 0.28,
+          transform: [{ translateY: imageHeight * 0.13 }, { scale: 0.94 }],
+        },
+        55: {
+          opacity: 1,
+          transform: [{ translateY: imageHeight * -0.025 }, { scale: 1.02 }],
+        },
+        100: {
+          opacity: 1,
+          transform: [{ translateY: 0 }, { scale: 1 }],
+        },
+      }).duration(460),
+    [imageHeight]
+  );
 
   if (!mascotIsActive) {
     return null;
@@ -151,43 +246,15 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
           {/* 규칙이 적용되는 경우: bubble 이미지 (way 이미지 아래, y축으로 위에 위치) */}
           {isRuleAppliedToCurrentCount && currentRule && (
             <>
-              {/* 다중 규칙일 때: 다음 규칙 미리보기 버블 (y- x- z-, 최대 2개) */}
-              {appliedRules.length > 1 &&
-                [1, 2].slice(0, Math.min(2, appliedRules.length - 1)).map((offset) => {
-                  const nextRule = appliedRules[(currentRuleIndex + offset) % appliedRules.length];
-                  const bubbleWidth = imageWidth * BUBBLE_SIZE_SCALE;
-                  const bubbleHeight = imageHeight * BUBBLE_SIZE_SCALE;
-                  // 원래 버블의 중앙 x 좌표를 유지하도록 left 위치 조정
-                  const originalCenterX = imageWidth * 0.05 + imageWidth / 2;
-                  const newLeft = originalCenterX - bubbleWidth / 2 - imageWidth * 0.04 * offset;
-                  return (
-                    // 미리보기 버블
-                    <View
-                      key={offset}
-                      style={{
-                        position: 'absolute',
-                        width: bubbleWidth,
-                        height: bubbleHeight,
-                        top: imageHeight * -0.8 - imageHeight * 0.08 * offset,
-                        left: newLeft,
-                        zIndex: -offset,
-                      }}
-                    >
-                      <EmphasisBubbleIcon
-                        width={bubbleWidth}
-                        height={bubbleHeight}
-                        color={nextRule.color}
-                      />
-                    </View>
-                  );
-                })}
               {/* 다중 규칙일 때 라벨 표시 (말풍선 위쪽에 분리, 터치 통과 → 아래 Pressable 전달) */}
               {appliedRules.length > 1 && (
                 <View
                   className="absolute left-0 right-0 items-center"
                   style={{
-                    top: imageHeight * -1.3,
-                    zIndex: 10,
+                    top:
+                      imageHeight *
+                      (-1.3 - STACK_VERTICAL_GAP_RATIO * Math.max(0, visibleRules.length - 2)),
+                    zIndex: 1,
                   }}
                   pointerEvents="none"
                 >
@@ -196,49 +263,144 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
                   </Text>
                 </View>
               )}
-              {/* 규칙 말풍선 이미지 */}
-              <View
-                style={{
-                  position: 'absolute',
-                  width: imageWidth * BUBBLE_SIZE_SCALE,
-                  height: imageHeight * BUBBLE_SIZE_SCALE,
-                  top: imageHeight * -0.8,
-                  // 원래 버블의 중앙 x 좌표를 유지하도록 left 위치 조정
-                  left: imageWidth * 0.05 + imageWidth / 2 - (imageWidth * BUBBLE_SIZE_SCALE) / 2,
-                  zIndex: 0, // way 이미지보다 아래
-                }}
-              >
-                <EmphasisBubbleIcon
-                  width={imageWidth * BUBBLE_SIZE_SCALE}
-                  height={imageHeight * BUBBLE_SIZE_SCALE}
-                  color={currentRule.color}
-                />
-              </View>
-              {/* 규칙 메시지 텍스트 (말풍선 위에 표시) */}
-              <View
-                style={{
-                  position: 'absolute',
-                  top: imageHeight * -0.8,
-                  left: imageWidth * TEXT_CONTAINER_LEFT_RATIO,
-                  width: imageWidth * TEXT_CONTAINER_WIDTH_RATIO,
-                  height: imageHeight,
-                  justifyContent: 'center',
-                  alignItems: 'center',
-                  zIndex: 1, // 버블 이미지 위에 텍스트
-                }}
-              >
-                {/* 규칙 메시지 텍스트 */}
-                <Text
-                  className="font-bold text-center"
-                  style={{
-                    fontSize: textFontSize,
-                    color: isDarkColor(currentRule.color) ? '#ffffff' : '#000000',
-                  }}
-                  allowFontScaling={false}
-                >
-                  {currentRule.message}
-                </Text>
-              </View>
+              {/* 규칙 말풍선 스택 (뒤쪽으로 갈수록 y축으로만 이동하고 점점 작아짐) */}
+              {visibleRules
+                .slice()
+                .reverse()
+                .map(({ stackIndex, rule }) => {
+                  const ruleKey = buildRuleKey(rule);
+                  const bubbleBaseWidth = imageWidth * BUBBLE_SIZE_SCALE;
+                  const bubbleBaseHeight = imageHeight * BUBBLE_SIZE_SCALE;
+                  const bubbleBaseLeft = imageWidth * BUBBLE_BASE_LEFT_RATIO;
+                  const bubbleBaseTop = imageHeight * -0.8;
+                  const scale = 1 - STACK_SCALE_STEP * stackIndex;
+                  const bubbleTop = bubbleBaseTop - imageHeight * STACK_VERTICAL_GAP_RATIO * stackIndex;
+                  const bubbleLeft = bubbleBaseLeft;
+                  const isCurrentBubble = stackIndex === 0;
+                  const shouldSkipLayoutAnimation =
+                    movedToBackRuleKey === ruleKey && stackIndex === visibleRules.length - 1;
+                  const shouldAnimateEnterExit = hasMountedStackRef.current && !preferReducedMotion;
+                  const shouldUseDisappearingExitAnimation =
+                    shouldAnimateEnterExit && movedToBackRuleKey !== ruleKey;
+                  const shouldUseFloatingThirdBubbleEnterAnimation =
+                    shouldAnimateEnterExit && stackIndex === MAX_VISIBLE_RULE_BUBBLES - 1;
+
+                  return (
+                    <Animated.View
+                      key={ruleKey}
+                      layout={
+                        preferReducedMotion || shouldSkipLayoutAnimation
+                          ? undefined
+                          : LinearTransition.duration(280)
+                      }
+                      entering={
+                        shouldUseFloatingThirdBubbleEnterAnimation
+                          ? floatingThirdBubbleEnterAnimation
+                          : shouldAnimateEnterExit
+                          ? FadeIn.duration(180).withInitialValues({
+                              opacity: 0,
+                            })
+                          : undefined
+                      }
+                      exiting={
+                        shouldUseDisappearingExitAnimation
+                          ? disappearingBubbleExitAnimation
+                          : undefined
+                      }
+                      pointerEvents="none"
+                      style={{
+                        position: 'absolute',
+                        width: bubbleBaseWidth,
+                        height: bubbleBaseHeight,
+                        top: bubbleTop,
+                        left: bubbleLeft,
+                        zIndex: 1,
+                      }}
+                    >
+                      <Animated.View
+                        pointerEvents="none"
+                        exiting={
+                          shouldUseDisappearingExitAnimation
+                            ? disappearingBubbleGhostExitAnimation
+                            : undefined
+                        }
+                        style={{
+                          position: 'absolute',
+                          top: 0,
+                          left: 0,
+                          width: bubbleBaseWidth,
+                          height: bubbleBaseHeight,
+                          opacity: 0,
+                        }}
+                      >
+                        {[0.16, 0.1, 0.06].map((layerOpacity, layerIndex) => {
+                          const ghostScale = 1.05 + layerIndex * 0.07;
+                          const ghostOffsetY = imageHeight * 0.015 * layerIndex;
+
+                          return (
+                            <View
+                              key={`${ruleKey}-ghost-${layerIndex}`}
+                              pointerEvents="none"
+                              style={{
+                                position: 'absolute',
+                                top: ghostOffsetY,
+                                left: 0,
+                                width: bubbleBaseWidth,
+                                height: bubbleBaseHeight,
+                                opacity: layerOpacity,
+                                transform: [{ scale: ghostScale }],
+                              }}
+                            >
+                              <EmphasisBubbleIcon
+                                width={bubbleBaseWidth}
+                                height={bubbleBaseHeight}
+                                color={rule.color}
+                              />
+                            </View>
+                          );
+                        })}
+                      </Animated.View>
+                      <View
+                        style={{
+                          width: bubbleBaseWidth,
+                          height: bubbleBaseHeight,
+                          transform: [{ scale }],
+                        }}
+                      >
+                        <EmphasisBubbleIcon
+                          width={bubbleBaseWidth}
+                          height={bubbleBaseHeight}
+                          color={rule.color}
+                        />
+                      </View>
+                      {isCurrentBubble && (
+                        <View
+                          style={{
+                            position: 'absolute',
+                            top: 0,
+                            left: bubbleBaseWidth * TEXT_CONTAINER_IN_BUBBLE_LEFT_RATIO,
+                            width: bubbleBaseWidth * TEXT_CONTAINER_IN_BUBBLE_WIDTH_RATIO,
+                            height: bubbleBaseHeight,
+                            justifyContent: 'center',
+                            alignItems: 'center',
+                          }}
+                        >
+                          {/* 규칙 메시지 텍스트 */}
+                          <Text
+                            className="font-bold text-center"
+                            style={{
+                              fontSize: textFontSize,
+                              color: isDarkColor(rule.color) ? '#ffffff' : '#000000',
+                            }}
+                            allowFontScaling={false}
+                          >
+                            {rule.message}
+                          </Text>
+                        </View>
+                      )}
+                    </Animated.View>
+                  );
+                })}
             </>
           )}
           {/* 방향 이미지 마스코트 어쩌미 (위에 표시) */}


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #89 


## 🛠 작업 내용

- 참고 자료 : https://jitter.video/file/?id=GYFDCu39fagnSskh6gkwG&nodeId=s4BRbnBS1f8L4atA3Z_TY
  - 기존에 찾아둔 자료는 아래쪽에 쌓여있고 위쪽으로 빠져나오는 스택 애니메이션인데, 적용해보니 어쩌미(방향이)를 가리게 되어 답답한 느낌이 들었습니다. 그래서 반대 방향의 스택 애니메이션 레퍼런스를 새로 찾아 참고해 만들었습니다.

- react-native-reanimated의 Keyframe 기반 커스텀 entering/exiting(블러 퇴장 + 잔상 레이어, 꼬리 떠오름 등장)과 LinearTransition으로 스택 내 말풍선의 y축 이동을 분리 구현했습니다.
- 2~3개 규칙처럼 같은 규칙이 스택 안에서 위치만 바뀌는 케이스에서도 Reanimated가 퇴장/진입을 인식하도록, 말풍선 key에 단조증가 카운터 기반 "도착 시점"(${ruleKey}@${arrivalTime})을 섞어 실제 mount/unmount가 일어나게 했습니다.
- 접근성 측면에서 usePreferReducedMotion 훅을 존중해 감속 모드에서는 모든 커스텀 애니메이션을 비활성화하도록 일관되게 처리했습니다.

https://github.com/user-attachments/assets/edc45135-e518-49e1-bc00-a1bb367ff3e5


## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)

- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 시스템 폰트 사이즈, 화면 크기 변화에 대응하는 걸 확인했습니다.
- [x] 동료 작업자에게 수정 사항을 공유했습니다. 