### PR TITLE
refactor: 어쩌미 알림 설정 페이지 진입점 수정

### DIFF
--- a/src/components/common/ActivateToggle.tsx
+++ b/src/components/common/ActivateToggle.tsx
@@ -5,7 +5,6 @@ import { activateIcons } from '@assets/images';
 interface ActivateToggleProps {
   mascotIsActive: boolean;
   onToggle: () => void;
-  onLongPress?: () => void;
   size?: number;
 }
 
@@ -16,11 +15,10 @@ interface ActivateToggleProps {
 const ActivateToggle: React.FC<ActivateToggleProps> = ({
   mascotIsActive,
   onToggle,
-  onLongPress,
   size = 23,
 }) => {
   return (
-    <TouchableOpacity onPress={onToggle} onLongPress={onLongPress}>
+    <TouchableOpacity onPress={onToggle}>
       <Image
         source={activateIcons[mascotIsActive ? 'active' : 'inactive']}
         style={{ width: size, height: size }}

--- a/src/components/common/Tooltip.tsx
+++ b/src/components/common/Tooltip.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Animated, LayoutChangeEvent } from 'react-native';
+import { Animated } from 'react-native';
 import { View, Text } from 'react-native';
 import Svg, { Path } from 'react-native-svg';
 
@@ -8,8 +8,6 @@ interface TooltipProps {
   containerClassName?: string;
   /** top: 위 화살표+아래 박스. bottom: 위 박스+아래 화살표(아래 방향). left: 왼쪽 화살+오른쪽 박스 */
   placement?: 'top' | 'bottom' | 'left';
-  // 화면 기준 타겟 X좌표(px). placement top/bottom일 때 화살표 가로 정렬
-  targetAnchorX?: number;
   /** true: 언마운트 없이 투명 처리만(슬라이드 모달 열림 등). 4초 타이머는 마운트당 1회만 진행 */
   visuallyHidden?: boolean;
 }
@@ -18,16 +16,12 @@ const Tooltip: React.FC<TooltipProps> = ({
   text,
   containerClassName,
   placement = 'top',
-  targetAnchorX,
   visuallyHidden = false,
 }) => {
   const [visible, setVisible] = useState(true);
   const opacity = useRef(new Animated.Value(1)).current;
   const AUTO_HIDE_MS = 4000;
   const FADE_OUT_MS = 400;
-  const bodyRef = useRef<View | null>(null);
-  const [arrowLeftPx, setArrowLeftPx] = useState<number | null>(null);
-  const ARROW_HALF_WIDTH = 6; // Svg width 12 기준 (placement top)
   /** 화살표·박스 경계 서브픽셀 틈 방지(1px만 박스 쪽으로 겹침; 삼각형 스케일 키우는 것과 달리 두께는 그대로) */
   const ARROW_BOX_OVERLAP_PX = 1;
 
@@ -63,20 +57,6 @@ const Tooltip: React.FC<TooltipProps> = ({
       opacity.stopAnimation();
     };
   }, [AUTO_HIDE_MS, FADE_OUT_MS, opacity]);
-
-  // targetAnchorX가 바뀌면(ex: onLayout으로 resolvedWidth 갱신)
-  // measureInWindow로 화살표 위치를 재계산 (placement top/bottom 전용)
-  useEffect(() => {
-    if ((placement !== 'top' && placement !== 'bottom') || !targetAnchorX || !bodyRef.current) {
-      return;
-    }
-    bodyRef.current.measureInWindow((x, _y, w) => {
-      if (x === undefined || w === undefined) { return; }
-      const raw = targetAnchorX - x;
-      const clamped = Math.max(ARROW_HALF_WIDTH, Math.min(w - ARROW_HALF_WIDTH, raw));
-      setArrowLeftPx(clamped);
-    });
-  }, [placement, targetAnchorX]);
 
   if (!visible) {
     return null;
@@ -117,32 +97,14 @@ const Tooltip: React.FC<TooltipProps> = ({
               height={20}
               style={{
                 position: 'absolute',
-                left: arrowLeftPx ?? '50%',
+                left: '50%',
                 bottom: -8 + ARROW_BOX_OVERLAP_PX,
-                transform: [
-                  { translateX: -(arrowLeftPx != null ? ARROW_HALF_WIDTH : 6) },
-                  { rotate: '180deg' },
-                ],
+                transform: [{ translateX: -6 }, { rotate: '180deg' }],
               }}
             >
               <Path d="M0 20 L5 5 Q6 4 7 5 L12 20 Z" fill="rgba(0,0,0,1)" />
             </Svg>
-            <View
-              ref={(ref) => { bodyRef.current = ref; }}
-              className="px-2 py-3 rounded-md bg-black mb-3"
-              style={{ maxWidth: 240 }}
-              onLayout={(_e: LayoutChangeEvent) => {
-                if (!targetAnchorX || !bodyRef.current) {
-                  setArrowLeftPx(null);
-                  return;
-                }
-                bodyRef.current.measureInWindow((x, _y, width) => {
-                  const raw = targetAnchorX - x;
-                  const clamped = Math.max(ARROW_HALF_WIDTH, Math.min(width - ARROW_HALF_WIDTH, raw));
-                  setArrowLeftPx(clamped);
-                });
-              }}
-            >
+            <View className="px-2 py-3 rounded-md bg-black mb-3" style={{ maxWidth: 240 }}>
               {text ? (
                 <Text className="text-white text-xs text-center">{text}</Text>
               ) : null}
@@ -164,30 +126,14 @@ const Tooltip: React.FC<TooltipProps> = ({
               height={20}
               style={{
                 position: 'absolute',
-                left: arrowLeftPx ?? '50%',
+                left: '50%',
                 top: -8 + ARROW_BOX_OVERLAP_PX,
-                transform: [{ translateX: -(arrowLeftPx != null ? ARROW_HALF_WIDTH : 6) }],
+                transform: [{ translateX: -6 }],
               }}
             >
               <Path d="M0 20 L5 5 Q6 4 7 5 L12 20 Z" fill="rgba(0,0,0,1)" />
             </Svg>
-            <View
-              ref={(ref) => { bodyRef.current = ref; }}
-              className="px-2 py-3 rounded-md bg-black mt-3"
-              style={{ maxWidth: 240 }}
-              onLayout={(_e: LayoutChangeEvent) => {
-                if (!targetAnchorX || !bodyRef.current) {
-                  setArrowLeftPx(null); // 기본 중앙 정렬
-                  return;
-                }
-                // 박스의 화면 기준 좌표를 가져와 타겟 X와의 차이로 화살표 위치(px) 계산
-                bodyRef.current.measureInWindow((x, _y, width) => {
-                  const raw = targetAnchorX - x;
-                  const clamped = Math.max(ARROW_HALF_WIDTH, Math.min(width - ARROW_HALF_WIDTH, raw));
-                  setArrowLeftPx(clamped);
-                });
-              }}
-            >
+            <View className="px-2 py-3 rounded-md bg-black mt-3" style={{ maxWidth: 240 }}>
               {text ? (
                 <Text className="text-white text-xs text-center">{text}</Text>
               ) : null}

--- a/src/components/counter/CounterDirection.tsx
+++ b/src/components/counter/CounterDirection.tsx
@@ -18,6 +18,7 @@ interface CounterDirectionProps {
   imageWidth: number;
   imageHeight: number;
   onToggleWay: () => void;
+  onLongPress?: () => void;
 }
 
 // 버블 이미지 크기 상수
@@ -111,6 +112,7 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
   imageWidth,
   imageHeight,
   onToggleWay,
+  onLongPress,
 }) => {
   const preferReducedMotion = usePreferReducedMotion();
   /**
@@ -285,6 +287,7 @@ const CounterDirection: React.FC<CounterDirectionProps> = ({
     <View style={{ height: imageHeight }}>
       <Pressable
         onPress={wayIsChange ? onToggleWay : undefined}
+        onLongPress={onLongPress}
         style={{ transform: [{ translateY: imageHeight * DIRECTION_VERTICAL_OFFSET_RATIO }] }}
         focusable={false}
         accessible={false}

--- a/src/navigation/HeaderOptions.tsx
+++ b/src/navigation/HeaderOptions.tsx
@@ -79,7 +79,6 @@ export const getHeaderRightWithInfoEditAndSettings = (
 export const getHeaderRightWithActivateInfoSettings = (
   navigation: NativeStackNavigationProp<RootStackParamList>,
   mascotIsActive: boolean,
-  onActivatePress: () => void,
   timerIsActive: boolean,
   onTimerPress: () => void,
   voiceCommandsEnabled: boolean,
@@ -142,8 +141,7 @@ export const getHeaderRightWithActivateInfoSettings = (
       <View style={{ marginRight: 13 }}>
         <ActivateToggle
           mascotIsActive={mascotIsActive}
-          onToggle={onActivatePress}
-          onLongPress={() => navigation.navigate('WaySetting', { counterId })}
+          onToggle={() => navigation.navigate('WaySetting', { counterId })}
         />
       </View>
 

--- a/src/screens/CounterDetail.tsx
+++ b/src/screens/CounterDetail.tsx
@@ -496,6 +496,7 @@ const CounterDetail = () => {
                     imageWidth={imageWidth}
                     imageHeight={imageHeight}
                     onToggleWay={toggleWay}
+                    onLongPress={() => navigation.navigate('WaySetting', { counterId: counter.id })}
                   />
                 </View>
               )}

--- a/src/screens/CounterDetail.tsx
+++ b/src/screens/CounterDetail.tsx
@@ -116,7 +116,6 @@ const CounterDetail = () => {
     handleClose,
     handleTargetCountOpen,
     handleTargetCountConfirm,
-    toggleMascotIsActive,
     toggleWay,
     toggleTimerIsActive,
     toggleTimerIsPlaying,
@@ -391,7 +390,6 @@ const CounterDetail = () => {
         getHeaderRightWithActivateInfoSettings(
           navigation,
           mascotIsActive,
-          toggleMascotIsActive,
           counter.timerIsActive,
           toggleTimerIsActive,
           isVoiceCommandsEnabled,
@@ -409,7 +407,6 @@ const CounterDetail = () => {
     mascotIsActive,
     screenSize,
     subSlideModalsEnabled,
-    toggleMascotIsActive,
     toggleSubSlideModalsEnabled,
     toggleTimerIsActive,
     toggleVoiceCommands,
@@ -458,15 +455,6 @@ const CounterDetail = () => {
           screenSize={screenSize}
           onPress={handleTargetCountOpen}
         />
-
-        {/* 헤더 활성 아이콘 안내 툴팁 (헤더 대신 화면 위층에 표시) */}
-        {screenSize !== ScreenSize.COMPACT && tooltipEnabled && (
-          <Tooltip
-            text="길게 눌러 어쩌미 알림 단 설정하기"
-            containerClassName="absolute right-3 top-2 z-50"
-            targetAnchorX={resolvedWidth - 106}
-          />
-        )}
 
         <View
           className="absolute left-0 right-0 bottom-0 w-full items-center justify-start"


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #194 


## 🛠 작업 내용

- '활성이' 터치로 알림 설정 페이지로 이동하도록 함
- 기존 '활성이'를 가리키던 툴팁 사용 제거. '활성이'를 가리키기 위해 anchorX를 사용하던 툴팁 컴포넌트 내 코드 사용처가 없어짐에 따라 제거.
- '방향이'를 길게 눌러 알림 설정 페이지로 이동하도록 수정 

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)

- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 시스템 폰트 사이즈, 화면 크기 변화에 대응하는 걸 확인했습니다.
- [x] 동료 작업자에게 수정 사항을 공유했습니다. 