### PR TITLE
fix: 숫자 명령어로 음성 인식 증감이 되지 않는 현상

### DIFF
--- a/src/hooks/useVoiceCommands.ts
+++ b/src/hooks/useVoiceCommands.ts
@@ -20,6 +20,18 @@ const IDLE_RESTART_DELAY_MS = 1500;
 const START_WATCHDOG_MS = 5000;
 // 세션 경계·지연 final 등으로 같은 키워드가 짧은 간격에 두 번 오는 경우 1회만 실행한다.
 const KEYWORD_ACTION_DEDUP_MS = 400;
+const KOREAN_NUMBER_COMMAND_WORDS = new Set([
+  '하나',
+  '둘',
+  '셋',
+  '넷',
+  '다섯',
+  '여섯',
+  '일곱',
+  '여덟',
+  '아홉',
+  '열',
+]);
 export const VOICE_LISTENING_TEXT = '듣는 중...';
 const MODEL_NOT_DOWNLOADED_MESSAGE_FRAGMENT =
   'requested language is supported, but not yet downloaded';
@@ -306,8 +318,9 @@ export function useVoiceCommands(
     // 같은 슬롯에서 "군지" → "건지"처럼 유사어 교정만 일어난 경우는
     // 동작이 같은 키워드면 접두어 길이에 포함해 한 번만 실행되게 한다.
     const runActionsFromTranscript = (text: string) => {
+      const previousWords = lastTranscriptWords;
       const nextWords = normalizeTranscriptWords(text);
-      const prevCanonical = lastTranscriptWords.map((word) =>
+      const prevCanonical = previousWords.map((word) =>
         canonicalizeKeywordForTranscriptDiff(word, keywordSets)
       );
       const nextCanonical = nextWords.map((word) =>
@@ -316,11 +329,19 @@ export function useVoiceCommands(
       const commonPrefixLength = getCommonPrefixLength(prevCanonical, nextCanonical);
       let newWords = nextWords.slice(commonPrefixLength);
 
-      const prevTail = lastTranscriptWords[lastTranscriptWords.length - 1];
-      if (
+      const prevTail = previousWords[previousWords.length - 1];
+      const shouldSkipRepeatedTail =
         prevTail !== undefined &&
         newWords.length > 0 &&
-        newWords.every((w) => w === prevTail)
+        newWords.every((w) => w === prevTail);
+      const isRepeatedKoreanNumberCommand =
+        prevTail !== undefined &&
+        KOREAN_NUMBER_COMMAND_WORDS.has(prevTail) &&
+        getWordAction(prevTail, keywordSets) !== null;
+
+      if (
+        shouldSkipRepeatedTail &&
+        !isRepeatedKoreanNumberCommand
       ) {
         lastTranscriptWords = nextWords;
         return;
@@ -330,42 +351,48 @@ export function useVoiceCommands(
       newWords.forEach((word) => {
         const action = getWordAction(word, keywordSets);
         if (action === 'add') {
-          if (!shouldSkipDuplicateKeywordAction(action, word)) {
+          const shouldSkipDedup = shouldSkipDuplicateKeywordAction(action, word);
+          if (!shouldSkipDedup) {
             onAddRef.current(word);
           }
           return;
         }
 
         if (action === 'subtract') {
-          if (!shouldSkipDuplicateKeywordAction(action, word)) {
+          const shouldSkipDedup = shouldSkipDuplicateKeywordAction(action, word);
+          if (!shouldSkipDedup) {
             onSubtractRef.current(word);
           }
           return;
         }
 
         if (action === 'subAdd') {
-          if (!shouldSkipDuplicateKeywordAction(action, word)) {
+          const shouldSkipDedup = shouldSkipDuplicateKeywordAction(action, word);
+          if (!shouldSkipDedup) {
             onSubAddRef.current?.(word);
           }
           return;
         }
 
         if (action === 'subSubtract') {
-          if (!shouldSkipDuplicateKeywordAction(action, word)) {
+          const shouldSkipDedup = shouldSkipDuplicateKeywordAction(action, word);
+          if (!shouldSkipDedup) {
             onSubSubtractRef.current?.(word);
           }
           return;
         }
 
         if (action === 'mainReset') {
-          if (!shouldSkipDuplicateKeywordAction(action, word)) {
+          const shouldSkipDedup = shouldSkipDuplicateKeywordAction(action, word);
+          if (!shouldSkipDedup) {
             onMainResetRef.current?.(word);
           }
           return;
         }
 
         if (action === 'subReset') {
-          if (!shouldSkipDuplicateKeywordAction(action, word)) {
+          const shouldSkipDedup = shouldSkipDuplicateKeywordAction(action, word);
+          if (!shouldSkipDedup) {
             onSubResetRef.current?.(word);
           }
         }


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #210 


## 🛠 작업 내용

- Android 온디바이스 STT가 `다섯`, `열` 같은 숫자 명령어를 `다섯 다섯`처럼 누적 transcript로 보내고, `유진`·`아홉`은 중간에 `유`·`아` 같은 미완성 토큰이 끼어 기존 diff 로직과 결과가 달랐다.
- `runActionsFromTranscript`의 `skip repeated tail` 분기가 두 번째 이후 같은 토큰을 “이미 처리한 반복”으로 보고 액션 실행 전에 return하여, 숫자 명령어만 1회 증감되는 현상이 발생했다.
- `하나`~`열`이 실제 등록된 커스텀 명령어일 때만 해당 skip을 우회하도록 예외를 두어, 다른 명령어의 중복 방지·유사어 교정 보호 로직은 그대로 유지했다.

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)

- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 시스템 폰트 사이즈, 화면 크기 변화에 대응하는 걸 확인했습니다.
- [x] 동료 작업자에게 수정 사항을 공유했습니다. 