### PR TITLE
fix: 데이터 불러오기 '카운터 데이터 형식이 올바르지 않습니다' 오류

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -106,8 +106,8 @@ android {
         applicationId 'com.simpleknitcounter'
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 49
-        versionName "1.5.0"
+        versionCode 50
+        versionName "1.5.1-internal.1"
     }
     signingConfigs {
         debug {

--- a/src/screens/Setting.tsx
+++ b/src/screens/Setting.tsx
@@ -43,7 +43,7 @@ const Settings = () => {
 
           <SettingsAppInfo />
 
-          <SettingsVersion version="1.5.0" />
+          <SettingsVersion version="1.5.1-internal.1" />
         </ScrollView>
       </KeyboardAvoidingView>
     </SafeAreaView>

--- a/src/storage/backup.ts
+++ b/src/storage/backup.ts
@@ -330,9 +330,9 @@ const isEditLogType = (value: unknown): boolean => {
     || value === 'way_change_back';
 };
 
-/** 반복 규칙 색상이 #RRGGBB 형식인지 확인한다. */
+/** 반복 규칙 색상이 #RRGGBB 이거나, 불투명 alpha(#RRGGBBff)를 붙인 형식인지 확인한다. */
 const isHexColor = (value: unknown): value is string => {
-  return typeof value === 'string' && /^#[0-9A-Fa-f]{6}$/.test(value);
+  return typeof value === 'string' && /^#[0-9A-Fa-f]{6}(?:ff)?$/i.test(value);
 };
 
 /** info 객체 전체가 설정 화면에서 저장 가능한 형태인지 확인한다. */


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #220 


## 🛠 작업 내용

- 데이터 내보내기 한 뒤, 파일을 수정하지 않고 즉각 불러오기 했으나 '카운터 데이터 형식이 올바르지 않습니다' 안내 문구와 함께 불러올 수 없었습니다.

- 기존 데이터 불러오기 할 때 색상 코드 6자리만 허용했으나, 뒤에 알파값 ff를 붙여 8자리로 저장되는 경우가 있었습니다.
- 알파값 ff가 붙은 형태의 8자리 색상 코드 불러오기도 허용합니다.

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)

- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 시스템 폰트 사이즈, 화면 크기 변화에 대응하는 걸 확인했습니다.
- [x] 동료 작업자에게 수정 사항을 공유했습니다. 