### PR TITLE
refactor: 설정 페이지 설명글 툴팁 컴포넌트 사용하도록 수정

### DIFF
--- a/src/components/settings/SettingsBackup.tsx
+++ b/src/components/settings/SettingsBackup.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef, useState } from 'react';
-import { Text, TouchableOpacity, View } from 'react-native';
+import { TouchableOpacity, View } from 'react-native';
 import { CommonActions, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Star } from 'lucide-react-native';
@@ -177,11 +177,10 @@ const SettingsBackup: React.FC<SettingsBackupProps> = () => {
     <>
       {/* 백업 섹션: 제목·안내 문구·내보내기/불러오기(및 미구독 시 잠금 UI). */}
       <View className="mb-8">
-        <SettingsSectionHeader title="백업 및 복원" />
-        <Text className="mb-4 pl-6 pr-1 text-xs font-normal leading-5 text-darkgray">
-          앱 데이터는 이 기기에만 저장됩니다. 앱을 삭제하거나 기기를 바꾸면 데이터가
-          사라질 수 있으니, 파일로 내보내 두었다가 필요할 때 불러와 복구할 수 있습니다.
-        </Text>
+        <SettingsSectionHeader
+          title="백업 및 복원"
+          tooltipText="앱 데이터는 이 기기에만 저장됩니다. 앱을 삭제하거나 기기를 바꾸면 데이터가 사라질 수 있으니, 파일로 내보내 두었다가 필요할 때 불러와 복구할 수 있습니다."
+        />
         {/* IconBox 두 줄과, 미구독일 때만 씌우는 multiply·구매 진입·별 표시. */}
         <View className="relative">
           <IconBox

--- a/src/components/settings/SettingsSectionHeader.tsx
+++ b/src/components/settings/SettingsSectionHeader.tsx
@@ -1,10 +1,12 @@
 // src/components/settings/SettingsSectionHeader.tsx
 import React from 'react';
 import { View, Text } from 'react-native';
+import QuestionMarkTooltip from '@components/counter/QuestionMarkTooltip';
 
 export interface SettingsSectionHeaderProps {
   title: string;
   titleClassName?: string;
+  tooltipText?: string;
 }
 
 /**
@@ -13,12 +15,20 @@ export interface SettingsSectionHeaderProps {
 const SettingsSectionHeader: React.FC<SettingsSectionHeaderProps> = ({
   title,
   titleClassName = 'text-darkgray',
+  tooltipText,
 }) => {
   return (
     <View className="mb-2 flex-row items-center px-2">
-      <Text className={`mr-3 text-sm font-semibold ${titleClassName}`}>
-        {title}
-      </Text>
+      <View className="mr-3 flex-row items-center">
+        <Text className={`text-sm font-semibold ${titleClassName}`}>
+          {title}
+        </Text>
+        {tooltipText ? (
+          <View className="ml-1">
+            <QuestionMarkTooltip tooltipText={tooltipText} />
+          </View>
+        ) : null}
+      </View>
       <View className="flex-1 border-b border-lightgray" />
     </View>
   );


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #219 


## 🛠 작업 내용
- 설정 페이지의 설명 글을 툴팁 컴포넌트로 수정하면서
- 설정 섹션 제목 컴포넌트에 선택 옵션으로 구현하여 추가
<img width="494" height="410" alt="image" src="https://github.com/user-attachments/assets/a36bf5d0-9f06-4308-8f06-4d5bee29226d" />


## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)

- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 시스템 폰트 사이즈, 화면 크기 변화에 대응하는 걸 확인했습니다.
- [x] 동료 작업자에게 수정 사항을 공유했습니다. 