### PR TITLE
feat: 프로젝트 불러오기

### DIFF
--- a/src/assets/item-imports/awesome-knit-item-import-sample.json
+++ b/src/assets/item-imports/awesome-knit-item-import-sample.json
@@ -1,0 +1,196 @@
+{
+  "formatVersion": 1,
+  "appId": "awesome-knit-row-counter",
+  "importType": "item-import",
+  "dataVersion": 5,
+  "payload": {
+    "knitItems": [
+      {
+        "id": "counter_template_bangulbread_keyring",
+        "type": "counter",
+        "title": "방울빵 키링",
+        "count": 0,
+        "targetCount": 10,
+        "parentProjectId": null,
+        "subCount": 0,
+        "subRule": 0,
+        "subRuleIsActive": false,
+        "subModalIsOpen": false,
+        "mascotIsActive": true,
+        "wayIsChange": false,
+        "repeatRules": [
+          {
+            "message": "사슬3, 빼뜨, 사슬4,빼뜨",
+            "startNumber": 0,
+            "endNumber": 0,
+            "repeatCount": 1,
+            "endMode": "repeatCount",
+            "ruleNumber": 1,
+            "color": "#EF5777"
+          },
+          {
+            "message": "짧뜨7 (7)",
+            "startNumber": 1,
+            "endNumber": 0,
+            "repeatCount": 1,
+            "endMode": "repeatCount",
+            "ruleNumber": 1,
+            "color": "#574559"
+          },
+          {
+            "message": "늘리기7 (14)",
+            "startNumber": 2,
+            "endNumber": 0,
+            "repeatCount": 1,
+            "endMode": "repeatCount",
+            "ruleNumber": 1,
+            "color": "#04BFAD"
+          },
+          {
+            "message": "짧뜨1, 늘리기1",
+            "startNumber": 3,
+            "endNumber": 0,
+            "repeatCount": 1,
+            "endMode": "repeatCount",
+            "ruleNumber": 1,
+            "color": "#F2A922"
+          },
+          {
+            "message": "(21)",
+            "startNumber": 3,
+            "endNumber": 0,
+            "repeatCount": 1,
+            "endMode": "repeatCount",
+            "ruleNumber": 1,
+            "color": "#f2a922ff"
+          },
+          {
+            "message": "sc around",
+            "startNumber": 4,
+            "endNumber": 7,
+            "repeatCount": 0,
+            "endMode": "endNumber",
+            "ruleNumber": 1,
+            "color": "#D9B391"
+          },
+          {
+            "message": "(21)",
+            "startNumber": 4,
+            "endNumber": 7,
+            "repeatCount": 0,
+            "endMode": "endNumber",
+            "ruleNumber": 1,
+            "color": "#d9b391ff"
+          },
+          {
+            "message": "실 색 변경",
+            "startNumber": 7,
+            "endNumber": 1,
+            "repeatCount": 1,
+            "endMode": "repeatCount",
+            "ruleNumber": 1,
+            "color": "#A9CBD9"
+          },
+          {
+            "message": "짧뜨2, 줄이기",
+            "startNumber": 8,
+            "endNumber": 0,
+            "repeatCount": 2,
+            "endMode": "repeatCount",
+            "ruleNumber": 1,
+            "color": "#D4E157"
+          },
+          {
+            "message": "줄이기 (6)",
+            "startNumber": 10,
+            "endNumber": 0,
+            "repeatCount": 1,
+            "endMode": "repeatCount",
+            "ruleNumber": 1,
+            "color": "#DAC6E8"
+          },
+          {
+            "message": "(16)",
+            "startNumber": 8,
+            "endNumber": 0,
+            "repeatCount": 1,
+            "endMode": "repeatCount",
+            "ruleNumber": 1,
+            "color": "#d4e157ff"
+          },
+          {
+            "message": "(12)",
+            "startNumber": 9,
+            "endNumber": 0,
+            "repeatCount": 1,
+            "endMode": "repeatCount",
+            "ruleNumber": 1,
+            "color": "#FFA685"
+          }
+        ],
+        "sectionModalIsOpen": false,
+        "info": {
+          "startDate": "",
+          "endDate": "",
+          "gauge": "",
+          "yarn": "원작 : 얀메이크 착하면",
+          "needle": "원작 : 튤립 에티모 모사용 4/0호 코바늘",
+          "notes": "원작 :\n셋업 단에서 만든 3사슬 고리를 매직링처럼 사용합니다. 1단에서 해당 고리에 짧은 뜨기를 합니다.\n완성한 뒤, 셋업 단에서 만든 4사슬 고리에 군번줄을 달아 마무리합니다. 고리가 필요하지 않다면 4사슬 고리는 생략해도 괜찮습니다.\n\n원작에서는 매 단 빼뜨기와 기둥코를 세웠지만, 빼뜨기 없이 나선형으로 떠도 무방합니다."
+        }
+      },
+      {
+        "id": "proj_template_leaf_cuff",
+        "type": "project",
+        "title": "leaf cuff",
+        "counterIds": [
+          "counter_template_leaf_cuff_a",
+          "counter_template_leaf_cuff_b"
+        ]
+      },
+      {
+        "id": "counter_template_leaf_cuff_a",
+        "type": "counter",
+        "title": "ㄱ",
+        "count": 4,
+        "targetCount": 20,
+        "parentProjectId": "proj_template_leaf_cuff",
+        "subCount": 0,
+        "subRule": 0,
+        "subRuleIsActive": false,
+        "subModalIsOpen": false,
+        "mascotIsActive": true,
+        "wayIsChange": true,
+        "repeatRules": [],
+        "sectionModalIsOpen": true,
+        "way": "front"
+      },
+      {
+        "id": "counter_template_leaf_cuff_b",
+        "type": "counter",
+        "title": "ㄴ",
+        "count": 10,
+        "targetCount": 0,
+        "parentProjectId": "proj_template_leaf_cuff",
+        "subCount": 0,
+        "subRule": 0,
+        "subRuleIsActive": false,
+        "subModalIsOpen": false,
+        "mascotIsActive": true,
+        "wayIsChange": true,
+        "repeatRules": [
+          {
+            "message": "늘림 단",
+            "startNumber": 10,
+            "endNumber": 0,
+            "repeatCount": 5,
+            "endMode": "repeatCount",
+            "ruleNumber": 1,
+            "color": "#EF5777"
+          }
+        ],
+        "sectionModalIsOpen": false,
+        "way": "front"
+      }
+    ]
+  }
+}

--- a/src/assets/item-imports/awesome-knit-item-import-sample.json
+++ b/src/assets/item-imports/awesome-knit-item-import-sample.json
@@ -62,7 +62,7 @@
             "repeatCount": 1,
             "endMode": "repeatCount",
             "ruleNumber": 1,
-            "color": "#f2a922ff"
+            "color": "#f2a922"
           },
           {
             "message": "sc around",
@@ -116,7 +116,7 @@
             "repeatCount": 1,
             "endMode": "repeatCount",
             "ruleNumber": 1,
-            "color": "#d4e157ff"
+            "color": "#d4e157"
           },
           {
             "message": "(12)",

--- a/src/components/settings/SettingsBackup.tsx
+++ b/src/components/settings/SettingsBackup.tsx
@@ -184,7 +184,7 @@ const SettingsBackup: React.FC<SettingsBackupProps> = () => {
         {/* IconBox 두 줄과, 미구독일 때만 씌우는 multiply·구매 진입·별 표시. */}
         <View className="relative">
           <IconBox
-            title={isBusy ? '처리 중...' : '데이터 내보내기'}
+            title={isBusy ? '처리 중...' : '전체 데이터 내보내기'}
             iconName="download"
             disabled={!premiumUnlocked}
             onPress={async () => {
@@ -192,7 +192,7 @@ const SettingsBackup: React.FC<SettingsBackupProps> = () => {
             }}
           />
           <IconBox
-            title={isBusy ? '처리 중...' : '데이터 불러오기'}
+            title={isBusy ? '처리 중...' : '전체 데이터 불러오기'}
             iconName="upload"
             disabled={!premiumUnlocked}
             onPress={async () => {

--- a/src/components/settings/SettingsBackup.tsx
+++ b/src/components/settings/SettingsBackup.tsx
@@ -245,7 +245,7 @@ const SettingsBackup: React.FC<SettingsBackupProps> = () => {
           setImportConfirmVisible(false);
           setPendingImportDocument(null);
         }}
-        title="데이터 불러오기"
+        title="전체 데이터 불러오기"
         description={importDescription}
         onConfirm={async () => {
           await handleImportConfirm();

--- a/src/components/settings/SettingsItemImport.tsx
+++ b/src/components/settings/SettingsItemImport.tsx
@@ -1,12 +1,28 @@
 import React from 'react';
-import { View } from 'react-native';
+import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { Star } from 'lucide-react-native';
 
+import type { RootStackParamList } from '@navigation/AppNavigator';
+import { useIapContext } from '@provider/IapProvider';
+import { appTheme } from '@styles/appTheme';
 import IconBox from './IconBox';
 import SettingsSectionHeader from './SettingsSectionHeader';
 
 interface SettingsItemImportProps {}
 
+const PREMIUM_OVERLAY_STYLE = StyleSheet.create({
+  overlay: {
+    mixBlendMode: 'multiply',
+  },
+}).overlay;
+
 const SettingsItemImport: React.FC<SettingsItemImportProps> = () => {
+  const navigation =
+    useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const { premiumUnlocked } = useIapContext();
+
   const handleItemImportPress = () => {};
 
   return (
@@ -15,11 +31,37 @@ const SettingsItemImport: React.FC<SettingsItemImportProps> = () => {
         title="도안 불러오기"
         tooltipText="어쩜 전용 파일을 제공하는 도안을 구매하셨다면, 도안 파일을 불러와 미리 설정된 카운터를 사용하세요!"
       />
-      <IconBox
-        title="도안 불러오기"
-        iconName="upload"
-        onPress={handleItemImportPress}
-      />
+      <View className="relative">
+        <IconBox
+          title="도안 불러오기"
+          iconName="upload"
+          disabled={!premiumUnlocked}
+          onPress={handleItemImportPress}
+        />
+        {!premiumUnlocked ? (
+          <>
+            <View
+              className="pointer-events-none absolute -inset-2 z-[5] rounded-2xl bg-mediumgray overflow-hidden"
+              style={PREMIUM_OVERLAY_STYLE}
+            />
+            <TouchableOpacity
+              activeOpacity={1}
+              className="absolute -inset-2 z-[10] rounded-2xl"
+              onPress={() => navigation.navigate('PremiumPurchase')}
+              accessibilityRole="button"
+              accessibilityLabel="도안 불러오기, 프리미엄 전용"
+              accessibilityHint="탭하면 프리미엄 구매 화면으로 이동합니다."
+            />
+            <View className="pointer-events-none absolute inset-y-0 right-4 z-[20] w-6 items-center justify-center">
+              <Star
+                size={22}
+                color={appTheme.colors.premiumGold}
+                fill={appTheme.colors.premiumGold}
+              />
+            </View>
+          </>
+        ) : null}
+      </View>
     </View>
   );
 };

--- a/src/components/settings/SettingsItemImport.tsx
+++ b/src/components/settings/SettingsItemImport.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { View } from 'react-native';
+
+import IconBox from './IconBox';
+import SettingsSectionHeader from './SettingsSectionHeader';
+
+interface SettingsItemImportProps {}
+
+const SettingsItemImport: React.FC<SettingsItemImportProps> = () => {
+  const handleItemImportPress = () => {};
+
+  return (
+    <View className="mb-8">
+      <SettingsSectionHeader
+        title="도안 불러오기"
+        tooltipText="어쩜 전용 파일을 제공하는 도안을 구매하셨다면, 도안 파일을 불러와 미리 설정된 카운터를 사용하세요!"
+      />
+      <IconBox
+        title="도안 불러오기"
+        iconName="upload"
+        onPress={handleItemImportPress}
+      />
+    </View>
+  );
+};
+
+export default SettingsItemImport;

--- a/src/components/settings/SettingsItemImport.tsx
+++ b/src/components/settings/SettingsItemImport.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef, useState } from 'react';
-import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Text, TouchableOpacity, View } from 'react-native';
 import { CommonActions, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Star } from 'lucide-react-native';
@@ -21,11 +21,7 @@ import SettingsSectionHeader from './SettingsSectionHeader';
 
 interface SettingsItemImportProps {}
 
-const PREMIUM_OVERLAY_STYLE = StyleSheet.create({
-  overlay: {
-    mixBlendMode: 'multiply',
-  },
-}).overlay;
+const PREMIUM_OVERLAY_STYLE = { mixBlendMode: 'multiply' } as const;
 
 const SettingsItemImport: React.FC<SettingsItemImportProps> = () => {
   const navigation =
@@ -112,7 +108,6 @@ const SettingsItemImport: React.FC<SettingsItemImportProps> = () => {
     }
 
     setIsBusy(true);
-
     try {
       const document = await pickItemImportDocument();
 

--- a/src/components/settings/SettingsItemImport.tsx
+++ b/src/components/settings/SettingsItemImport.tsx
@@ -1,13 +1,21 @@
-import React from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
+import { CommonActions, useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Star } from 'lucide-react-native';
 
+import { ConfirmModal } from '@components/common/modals';
 import type { RootStackParamList } from '@navigation/AppNavigator';
 import { useIapContext } from '@provider/IapProvider';
 import { appTheme } from '@styles/appTheme';
 import { colorStyles } from '@styles/colorStyles';
+import {
+  getBundledItemImportDocument,
+  getItemImportSummary,
+  importItemImportDocument,
+  pickItemImportDocument,
+} from '@storage/backup';
+import type { ItemImportDocument } from '@storage/types';
 import IconBox from './IconBox';
 import SettingsSectionHeader from './SettingsSectionHeader';
 
@@ -24,71 +32,253 @@ const SettingsItemImport: React.FC<SettingsItemImportProps> = () => {
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const { premiumUnlocked } = useIapContext();
   const { containerClassName, textClassName } = colorStyles.light;
+  const onNoticeConfirmRef = useRef<(() => void) | null>(null);
 
-  const handleSampleItemImportPress = () => {};
-  const handleItemImportPress = () => {};
+  const [pendingImportDocument, setPendingImportDocument] = useState<ItemImportDocument | null>(
+    null
+  );
+  const [importConfirmVisible, setImportConfirmVisible] = useState(false);
+  const [errorModalVisible, setErrorModalVisible] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [noticeModalVisible, setNoticeModalVisible] = useState(false);
+  const [noticeTitle, setNoticeTitle] = useState('');
+  const [noticeMessage, setNoticeMessage] = useState('');
+  const [isBusy, setIsBusy] = useState(false);
+
+  const resetToMain = useCallback(() => {
+    navigation.dispatch(
+      CommonActions.reset({
+        index: 0,
+        routes: [{ name: 'Main' }],
+      })
+    );
+  }, [navigation]);
+
+  const showErrorModal = useCallback((message: string) => {
+    setErrorMessage(message);
+    setErrorModalVisible(true);
+  }, []);
+
+  const showNoticeModal = useCallback((
+    title: string,
+    description: string,
+    onConfirm?: () => void
+  ) => {
+    onNoticeConfirmRef.current = onConfirm ?? null;
+    setNoticeTitle(title);
+    setNoticeMessage(description);
+    setNoticeModalVisible(true);
+  }, []);
+
+  const getReadableErrorMessage = useCallback((error: unknown) => {
+    if (error instanceof Error && error.message.trim()) {
+      return error.message;
+    }
+
+    return '처리 중 오류가 발생했습니다.';
+  }, []);
+
+  const prepareImportDocument = useCallback((document: ItemImportDocument) => {
+    setPendingImportDocument(document);
+    setImportConfirmVisible(true);
+  }, []);
+
+  const handleSampleItemImportPress = useCallback(async () => {
+    if (isBusy) {
+      return;
+    }
+
+    setIsBusy(true);
+
+    try {
+      const document = getBundledItemImportDocument();
+      prepareImportDocument(document);
+    } catch (error) {
+      showErrorModal(getReadableErrorMessage(error));
+    } finally {
+      setIsBusy(false);
+    }
+  }, [getReadableErrorMessage, isBusy, prepareImportDocument, showErrorModal]);
+
+  const handleItemImportPress = useCallback(async () => {
+    if (isBusy) {
+      return;
+    }
+
+    setIsBusy(true);
+
+    try {
+      const document = await pickItemImportDocument();
+
+      if (!document) {
+        return;
+      }
+
+      prepareImportDocument(document);
+    } catch (error) {
+      showErrorModal(getReadableErrorMessage(error));
+    } finally {
+      setIsBusy(false);
+    }
+  }, [getReadableErrorMessage, isBusy, prepareImportDocument, showErrorModal]);
+
+  const handleImportConfirm = useCallback(async () => {
+    if (!pendingImportDocument) {
+      return;
+    }
+
+    setIsBusy(true);
+
+    try {
+      await importItemImportDocument(pendingImportDocument);
+      setPendingImportDocument(null);
+      showNoticeModal(
+        '프로젝트 불러오기 완료',
+        '프로젝트 데이터를 불러왔습니다.\n확인을 누르면 메인 화면으로 돌아갑니다.',
+        resetToMain
+      );
+    } catch (error) {
+      console.error('SettingsItemImport: import item document failed', error);
+      showErrorModal(getReadableErrorMessage(error));
+    } finally {
+      setIsBusy(false);
+    }
+  }, [
+    getReadableErrorMessage,
+    pendingImportDocument,
+    resetToMain,
+    showErrorModal,
+    showNoticeModal,
+  ]);
+
+  const handleNoticeConfirm = useCallback(() => {
+    const callback = onNoticeConfirmRef.current;
+    onNoticeConfirmRef.current = null;
+    callback?.();
+  }, []);
+
+  const importDescription = pendingImportDocument
+    ? (() => {
+      const summary = getItemImportSummary(pendingImportDocument);
+
+      return [
+        '불러오기를 진행하면 현재 기기의 데이터에 프로젝트가 추가됩니다.',
+        '',
+        `프로젝트: ${summary.projectCount}개`,
+        `카운터: ${summary.counterCount}개`,
+        `전체 항목: ${summary.totalItems}개`,
+      ].join('\n');
+    })()
+    : '';
 
   return (
-    <View className="mb-8">
-      <SettingsSectionHeader
-        title="프로젝트 불러오기"
-        tooltipText={
-          [
-            '어쩜 전용 파일을 제공하는 도안을 구매하셨다면, 미리 세팅된 프로젝트 파일을 불러와 사용하세요!',
-            '',
-            '불러오기 전용 json 파일을 제작하고 싶은 도아너라면, 문의하기를 통해 연락 주세요. 협업해주시는 도아너님께 프리미엄 앱 코드를 발송해드립니다.',
-          ].join('\n')
-        }
-      />
-      <Text className={`px-2 pb-2 text-xs ${appTheme.tw.text.darkgray}`}>
-        목표단수, 알림설정이 미리 세팅된 프로젝트 파일을{'\n'}
-        불러올 수 있습니다.
-      </Text>
-      {/* try it! 이 포함된 맛보기 블럭. 아이콘 자리에 text가 들어가서 IconBox 사용하지 않음.*/}
-      <TouchableOpacity onPress={handleSampleItemImportPress} activeOpacity={0.7}>
-        <View className={`m-1.5 rounded-2xl p-4 ${containerClassName}`}>
-          <View className="flex-row items-center justify-between py-3">
-            <Text className={`text-base font-semibold ${textClassName}`}>
-              맛보기 프로젝트 불러오기
-            </Text>
-            <Text className={`text-sm font-bold ${appTheme.tw.text.primary['500']}`}>
-              try it!
-            </Text>
-          </View>
-        </View>
-      </TouchableOpacity>
-      <View className="relative">
-        <IconBox
+    <>
+      <View className="mb-8">
+        <SettingsSectionHeader
           title="프로젝트 불러오기"
-          iconName="upload"
-          disabled={!premiumUnlocked}
-          onPress={handleItemImportPress}
+          tooltipText={
+            [
+              '어쩜 전용 파일을 제공하는 도안을 구매하셨다면, 미리 세팅된 프로젝트 파일을 불러와 사용하세요!',
+              '',
+              '불러오기 전용 json 파일을 제작하고 싶은 도아너라면, 문의하기를 통해 연락 주세요. 협업해주시는 도아너님께 프리미엄 앱 코드를 발송해드립니다.',
+            ].join('\n')
+          }
         />
-        {!premiumUnlocked ? (
-          <>
-            <View
-              className="pointer-events-none absolute -inset-2 z-[5] rounded-2xl bg-mediumgray overflow-hidden"
-              style={PREMIUM_OVERLAY_STYLE}
-            />
-            <TouchableOpacity
-              activeOpacity={1}
-              className="absolute -inset-2 z-[10] rounded-2xl"
-              onPress={() => navigation.navigate('PremiumPurchase')}
-              accessibilityRole="button"
-              accessibilityLabel="도안 불러오기, 프리미엄 전용"
-              accessibilityHint="탭하면 프리미엄 구매 화면으로 이동합니다."
-            />
-            <View className="pointer-events-none absolute inset-y-0 right-4 z-[20] w-6 items-center justify-center">
-              <Star
-                size={22}
-                color={appTheme.colors.premiumGold}
-                fill={appTheme.colors.premiumGold}
-              />
+        <Text className={`px-2 pb-2 text-xs ${appTheme.tw.text.darkgray}`}>
+          목표단수, 알림설정이 미리 세팅된 프로젝트 파일을{'\n'}
+          불러올 수 있습니다.
+        </Text>
+        <TouchableOpacity
+          onPress={async () => {
+            await handleSampleItemImportPress();
+          }}
+          activeOpacity={0.7}
+          disabled={isBusy}
+        >
+          <View className={`m-1.5 rounded-2xl p-4 ${containerClassName}`}>
+            <View className="flex-row items-center justify-between py-3">
+              <Text className={`text-base font-semibold ${textClassName}`}>
+                {isBusy ? '처리 중...' : '맛보기 프로젝트 불러오기'}
+              </Text>
+              <Text className={`text-sm font-bold ${appTheme.tw.text.primary['500']}`}>
+                try it!
+              </Text>
             </View>
-          </>
-        ) : null}
+          </View>
+        </TouchableOpacity>
+        <View className="relative">
+          <IconBox
+            title={isBusy ? '처리 중...' : '프로젝트 불러오기'}
+            iconName="upload"
+            disabled={!premiumUnlocked || isBusy}
+            onPress={async () => {
+              await handleItemImportPress();
+            }}
+          />
+          {!premiumUnlocked ? (
+            <>
+              <View
+                className="pointer-events-none absolute -inset-2 z-[5] rounded-2xl bg-mediumgray overflow-hidden"
+                style={PREMIUM_OVERLAY_STYLE}
+              />
+              <TouchableOpacity
+                activeOpacity={1}
+                className="absolute -inset-2 z-[10] rounded-2xl"
+                onPress={() => navigation.navigate('PremiumPurchase')}
+                accessibilityRole="button"
+                accessibilityLabel="프로젝트 불러오기, 프리미엄 전용"
+                accessibilityHint="탭하면 프리미엄 구매 화면으로 이동합니다."
+              />
+              <View className="pointer-events-none absolute inset-y-0 right-4 z-[20] w-6 items-center justify-center">
+                <Star
+                  size={22}
+                  color={appTheme.colors.premiumGold}
+                  fill={appTheme.colors.premiumGold}
+                />
+              </View>
+            </>
+          ) : null}
+        </View>
       </View>
-    </View>
+
+      <ConfirmModal
+        visible={importConfirmVisible}
+        onClose={() => {
+          setImportConfirmVisible(false);
+          setPendingImportDocument(null);
+        }}
+        title="프로젝트 불러오기"
+        description={importDescription}
+        onConfirm={async () => {
+          await handleImportConfirm();
+        }}
+        confirmText="불러오기"
+        cancelText="취소"
+      />
+
+      <ConfirmModal
+        visible={noticeModalVisible}
+        onClose={() => {
+          onNoticeConfirmRef.current = null;
+          setNoticeModalVisible(false);
+        }}
+        title={noticeTitle}
+        description={noticeMessage}
+        onConfirm={handleNoticeConfirm}
+        confirmText="확인"
+        cancelText=""
+      />
+
+      <ConfirmModal
+        visible={errorModalVisible}
+        onClose={() => setErrorModalVisible(false)}
+        title="오류"
+        description={errorMessage}
+        onConfirm={() => setErrorModalVisible(false)}
+        confirmText="확인"
+        cancelText=""
+      />
+    </>
   );
 };
 

--- a/src/components/settings/SettingsItemImport.tsx
+++ b/src/components/settings/SettingsItemImport.tsx
@@ -44,7 +44,7 @@ const SettingsItemImport: React.FC<SettingsItemImportProps> = () => {
         목표단수, 알림설정이 미리 세팅된 프로젝트 파일을{'\n'}
         불러올 수 있습니다.
       </Text>
-      {/* try it! 이 포함된 맛보기 블럭. 아이콘 자리에 text가 들어가서 IconBox 사용하지 않음. */}
+      {/* try it! 이 포함된 맛보기 블럭. 아이콘 자리에 text가 들어가서 IconBox 사용하지 않음.*/}
       <TouchableOpacity onPress={handleSampleItemImportPress} activeOpacity={0.7}>
         <View className={`m-1.5 rounded-2xl p-4 ${containerClassName}`}>
           <View className="flex-row items-center justify-between py-3">

--- a/src/components/settings/SettingsItemImport.tsx
+++ b/src/components/settings/SettingsItemImport.tsx
@@ -32,8 +32,10 @@ const SettingsItemImport: React.FC<SettingsItemImportProps> = () => {
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const { premiumUnlocked } = useIapContext();
   const { containerClassName, textClassName } = colorStyles.light;
+  // 완료 모달에서 확인을 눌렀을 때 실행할 후속 동작(예: Main으로 이동)을 보관한다.
   const onNoticeConfirmRef = useRef<(() => void) | null>(null);
 
+  // 파일 선택 → 확인 모달 → 실제 import 실행 단계가 공유하는 상태들.
   const [pendingImportDocument, setPendingImportDocument] = useState<ItemImportDocument | null>(
     null
   );
@@ -45,6 +47,7 @@ const SettingsItemImport: React.FC<SettingsItemImportProps> = () => {
   const [noticeMessage, setNoticeMessage] = useState('');
   const [isBusy, setIsBusy] = useState(false);
 
+  // import 직후 목록 갱신 결과를 바로 보게 하려고 Main 스택으로 되돌린다.
   const resetToMain = useCallback(() => {
     navigation.dispatch(
       CommonActions.reset({
@@ -78,11 +81,13 @@ const SettingsItemImport: React.FC<SettingsItemImportProps> = () => {
     return '처리 중 오류가 발생했습니다.';
   }, []);
 
+  // 샘플 import/파일 import 모두 "검증된 문서를 모달에 올리는" 단계는 동일하다.
   const prepareImportDocument = useCallback((document: ItemImportDocument) => {
     setPendingImportDocument(document);
     setImportConfirmVisible(true);
   }, []);
 
+  // 무료 맛보기는 앱에 포함된 샘플 JSON을 동일한 import 파이프라인으로 태운다.
   const handleSampleItemImportPress = useCallback(async () => {
     if (isBusy) {
       return;
@@ -100,6 +105,7 @@ const SettingsItemImport: React.FC<SettingsItemImportProps> = () => {
     }
   }, [getReadableErrorMessage, isBusy, prepareImportDocument, showErrorModal]);
 
+  // 유료 import는 사용자가 고른 JSON을 파싱/검증한 뒤 확인 모달로 넘긴다.
   const handleItemImportPress = useCallback(async () => {
     if (isBusy) {
       return;
@@ -122,6 +128,7 @@ const SettingsItemImport: React.FC<SettingsItemImportProps> = () => {
     }
   }, [getReadableErrorMessage, isBusy, prepareImportDocument, showErrorModal]);
 
+  // 확인 모달 승인 후에만 실제 스토리지 병합을 수행한다.
   const handleImportConfirm = useCallback(async () => {
     if (!pendingImportDocument) {
       return;
@@ -151,12 +158,14 @@ const SettingsItemImport: React.FC<SettingsItemImportProps> = () => {
     showNoticeModal,
   ]);
 
+  // 완료 모달은 상황에 따라 서로 다른 후속 동작을 실행할 수 있어 ref 기반 콜백을 사용한다.
   const handleNoticeConfirm = useCallback(() => {
     const callback = onNoticeConfirmRef.current;
     onNoticeConfirmRef.current = null;
     callback?.();
   }, []);
 
+  // append 방식 import라는 점을 사용자가 이해할 수 있도록 대상 개수만 간단히 요약한다.
   const importDescription = pendingImportDocument
     ? (() => {
       const summary = getItemImportSummary(pendingImportDocument);

--- a/src/components/settings/SettingsItemImport.tsx
+++ b/src/components/settings/SettingsItemImport.tsx
@@ -235,7 +235,7 @@ const SettingsItemImport: React.FC<SettingsItemImportProps> = () => {
                 className="absolute -inset-2 z-[10] rounded-2xl"
                 onPress={() => navigation.navigate('PremiumPurchase')}
                 accessibilityRole="button"
-                accessibilityLabel="프로젝트 불러오기, 프리미엄 전용"
+                accessibilityLabel="프로젝트 불러오기"
                 accessibilityHint="탭하면 프리미엄 구매 화면으로 이동합니다."
               />
               <View className="pointer-events-none absolute inset-y-0 right-4 z-[20] w-6 items-center justify-center">

--- a/src/components/settings/SettingsItemImport.tsx
+++ b/src/components/settings/SettingsItemImport.tsx
@@ -7,6 +7,7 @@ import { Star } from 'lucide-react-native';
 import type { RootStackParamList } from '@navigation/AppNavigator';
 import { useIapContext } from '@provider/IapProvider';
 import { appTheme } from '@styles/appTheme';
+import { colorStyles } from '@styles/colorStyles';
 import IconBox from './IconBox';
 import SettingsSectionHeader from './SettingsSectionHeader';
 
@@ -22,7 +23,9 @@ const SettingsItemImport: React.FC<SettingsItemImportProps> = () => {
   const navigation =
     useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const { premiumUnlocked } = useIapContext();
+  const { containerClassName, textClassName } = colorStyles.light;
 
+  const handleSampleItemImportPress = () => {};
   const handleItemImportPress = () => {};
 
   return (
@@ -41,6 +44,19 @@ const SettingsItemImport: React.FC<SettingsItemImportProps> = () => {
         목표단수, 알림설정이 미리 세팅된 프로젝트 파일을{'\n'}
         불러올 수 있습니다.
       </Text>
+      {/* try it! 이 포함된 맛보기 블럭. 아이콘 자리에 text가 들어가서 IconBox 사용하지 않음. */}
+      <TouchableOpacity onPress={handleSampleItemImportPress} activeOpacity={0.7}>
+        <View className={`m-1.5 rounded-2xl p-4 ${containerClassName}`}>
+          <View className="flex-row items-center justify-between py-3">
+            <Text className={`text-base font-semibold ${textClassName}`}>
+              맛보기 프로젝트 불러오기
+            </Text>
+            <Text className={`text-sm font-bold ${appTheme.tw.text.primary['500']}`}>
+              try it!
+            </Text>
+          </View>
+        </View>
+      </TouchableOpacity>
       <View className="relative">
         <IconBox
           title="프로젝트 불러오기"

--- a/src/components/settings/SettingsItemImport.tsx
+++ b/src/components/settings/SettingsItemImport.tsx
@@ -28,12 +28,18 @@ const SettingsItemImport: React.FC<SettingsItemImportProps> = () => {
   return (
     <View className="mb-8">
       <SettingsSectionHeader
-        title="도안 불러오기"
-        tooltipText="어쩜 전용 파일을 제공하는 도안을 구매하셨다면, 도안 파일을 불러와 미리 설정된 카운터를 사용하세요!"
+        title="프로젝트 불러오기"
+        tooltipText={
+          [
+            '어쩜 전용 파일을 제공하는 도안을 구매하셨다면, 미리 세팅된 프로젝트 파일을 불러와 사용하세요!',
+            '',
+            '불러오기 전용 json 파일을 제작하고 싶은 도아너라면, 문의하기를 통해 연락 주세요. 협업해주시는 도아너님께 프리미엄 앱 코드를 발송해드립니다.',
+          ].join('\n')
+        }
       />
       <View className="relative">
         <IconBox
-          title="도안 불러오기"
+          title="프로젝트 불러오기"
           iconName="upload"
           disabled={!premiumUnlocked}
           onPress={handleItemImportPress}

--- a/src/components/settings/SettingsItemImport.tsx
+++ b/src/components/settings/SettingsItemImport.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, TouchableOpacity, View } from 'react-native';
+import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Star } from 'lucide-react-native';
@@ -37,6 +37,10 @@ const SettingsItemImport: React.FC<SettingsItemImportProps> = () => {
           ].join('\n')
         }
       />
+      <Text className={`px-2 pb-2 text-xs ${appTheme.tw.text.darkgray}`}>
+        목표단수, 알림설정이 미리 세팅된 프로젝트 파일을{'\n'}
+        불러올 수 있습니다.
+      </Text>
       <View className="relative">
         <IconBox
           title="프로젝트 불러오기"

--- a/src/components/settings/index.ts
+++ b/src/components/settings/index.ts
@@ -2,6 +2,7 @@
 export { default as SettingsCheckBoxes } from './SettingsCheckBoxes';
 export { default as SettingsVoiceCommands } from './SettingsVoiceCommands';
 export { default as SettingsBackup } from './SettingsBackup';
+export { default as SettingsItemImport } from './SettingsItemImport';
 export { default as SettingsDataManagement } from './SettingsDataManagement';
 export { default as SettingsAppInfo } from './SettingsAppInfo';
 export { default as SettingsColorThemeSelector } from './SettingsColorThemeSelector';

--- a/src/hooks/useMain.ts
+++ b/src/hooks/useMain.ts
@@ -18,6 +18,7 @@ import {
   buildReplicatedProjectBundle,
   ReplicatedProjectBundle,
 } from '@utils/replicationUtils';
+import { createUniqueItemId } from '@utils/itemIdUtils';
 import { useItemList } from './useItemList';
 
 /**
@@ -76,11 +77,11 @@ export const useMain = () => {
    * 아이템 생성 함수
    */
   const createNewItem = useCallback((type: string, title: string): Item => {
-    const timestamp = Date.now();
+    const reservedIds = new Set(getStoredItems().map((item) => item.id));
 
     if (type === 'project') {
       return {
-        id: `proj_${timestamp}`,
+        id: createUniqueItemId('proj', reservedIds),
         type: 'project',
         title,
         counterIds: [],
@@ -88,7 +89,7 @@ export const useMain = () => {
     }
 
     return {
-      id: `counter_${timestamp}`,
+      id: createUniqueItemId('counter', reservedIds),
       type: 'counter',
       title,
       count: 0,
@@ -193,7 +194,8 @@ export const useMain = () => {
       }
 
       if (itemToReplicate.type === 'counter') {
-        const newId = `counter_${Date.now()}`;
+        const reservedIds = new Set(getStoredItems().map((item) => item.id));
+        const newId = createUniqueItemId('counter', reservedIds);
         const cloned = cloneCounterForReplication(itemToReplicate, trimmed, newId, null);
         if (checkDuplicateName(cloned)) {
           setPendingItem(cloned);

--- a/src/hooks/useProjectDetail.ts
+++ b/src/hooks/useProjectDetail.ts
@@ -14,6 +14,7 @@ import {
 } from '@storage/settings';
 import { sortItems } from '@utils/sortUtils';
 import { suggestDuplicateTitle, cloneCounterForReplication } from '@utils/replicationUtils';
+import { createUniqueItemId } from '@utils/itemIdUtils';
 import { useItemList } from './useItemList';
 
 /**
@@ -74,9 +75,9 @@ export const useProjectDetail = () => {
    * 새 카운터 생성 함수
    */
   const createNewCounter = useCallback((title: string): Counter => {
-    const timestamp = Date.now();
+    const reservedIds = new Set(getStoredItems().map((item) => item.id));
     return {
-      id: `counter_${timestamp}`,
+      id: createUniqueItemId('counter', reservedIds),
       type: 'counter',
       title,
       count: 0,
@@ -199,7 +200,8 @@ export const useProjectDetail = () => {
         return false;
       }
 
-      const newId = `counter_${Date.now()}`;
+      const reservedIds = new Set(getStoredItems().map((item) => item.id));
+      const newId = createUniqueItemId('counter', reservedIds);
       const cloned = cloneCounterForReplication(
         counterToReplicate,
         trimmed,

--- a/src/screens/PremiumPurchase.tsx
+++ b/src/screens/PremiumPurchase.tsx
@@ -266,6 +266,13 @@ const PremiumPurchase: React.FC = () => {
               <View className={clsx('h-px w-[55%] self-center', appTheme.tw.bg.primary['200'])} />
 
               <View className="items-center justify-center px-2 py-3">
+                <Text className="w-full text-center text-lg font-bold leading-[22px] tracking-tight text-black">
+                  도안 불러오기
+                </Text>
+              </View>
+              <View className={clsx('h-px w-[55%] self-center', appTheme.tw.bg.primary['200'])} />
+
+              <View className="items-center justify-center px-2 py-3">
                 <Text className="w-full text-center text-sm font-normal leading-[18px] text-black">
                   개발자의 감사
                 </Text>

--- a/src/screens/PremiumPurchase.tsx
+++ b/src/screens/PremiumPurchase.tsx
@@ -267,7 +267,7 @@ const PremiumPurchase: React.FC = () => {
 
               <View className="items-center justify-center px-2 py-3">
                 <Text className="w-full text-center text-lg font-bold leading-[22px] tracking-tight text-black">
-                  도안 불러오기
+                  프로젝트 불러오기
                 </Text>
               </View>
               <View className={clsx('h-px w-[55%] self-center', appTheme.tw.bg.primary['200'])} />

--- a/src/screens/PremiumPurchase.tsx
+++ b/src/screens/PremiumPurchase.tsx
@@ -260,7 +260,7 @@ const PremiumPurchase: React.FC = () => {
 
               <View className="items-center justify-center px-2 py-3">
                 <Text className="w-full text-center text-lg font-bold leading-[22px] tracking-tight text-black">
-                  데이터 내보내기&파일 데이터 불러오기
+                  전체 데이터 내보내기&파일 데이터 불러오기
                 </Text>
               </View>
               <View className={clsx('h-px w-[55%] self-center', appTheme.tw.bg.primary['200'])} />

--- a/src/screens/Setting.tsx
+++ b/src/screens/Setting.tsx
@@ -8,6 +8,7 @@ import {
   SettingsCheckBoxes,
   SettingsColorThemeSelector,
   SettingsDataManagement,
+  SettingsItemImport,
   SettingsVersion,
   SettingsVoiceCommands,
 } from '@components/settings';
@@ -38,6 +39,7 @@ const Settings = () => {
           <SettingsVoiceCommands />
 
           <SettingsBackup />
+          <SettingsItemImport />
 
           <SettingsDataManagement />
 

--- a/src/storage/backup.ts
+++ b/src/storage/backup.ts
@@ -1,6 +1,7 @@
 import * as DocumentPicker from 'expo-document-picker';
 import * as FileSystem from 'expo-file-system';
 import * as Sharing from 'expo-sharing';
+import { createUniqueItemId } from '@utils/itemIdUtils';
 import type {
   Item,
   ItemImportCounter,
@@ -1085,16 +1086,21 @@ export const parseBackupDocument = (json: string): BackupDocument => {
 /**
  * 템플릿 문서의 ID를 현재 기기 전용 ID로 재발급하고,
  * import 대상에 없는 실행 상태 필드는 앱 기본값으로 보정한다.
+ * 기존 스토리지에 이미 있는 ID와도 충돌하지 않도록 현재 ID 집합을 함께 받는다.
  */
-const remapImportedItems = (items: ItemImportItem[]): Item[] => {
+const remapImportedItems = (
+  items: ItemImportItem[],
+  existingItems: Item[]
+): Item[] => {
   const baseTimestamp = Date.now();
   const oldIdToNewId = new Map<string, string>();
+  const reservedIds = new Set(existingItems.map((item) => item.id));
 
   // project/counter 모두 먼저 새 ID를 배정해 둬야 이후 참조 치환(counterIds/parentProjectId)이 단순해진다.
   items.forEach((item, index) => {
     const nextTimestamp = baseTimestamp + index;
     const prefix = item.type === 'project' ? 'proj' : 'counter';
-    oldIdToNewId.set(item.id, `${prefix}_${nextTimestamp}`);
+    oldIdToNewId.set(item.id, createUniqueItemId(prefix, reservedIds, nextTimestamp));
   });
 
   const normalizedItems = items.map((item, index): Item => {
@@ -1245,7 +1251,14 @@ export const getBundledItemImportDocument = (): ItemImportDocument => {
 
 /** 검증된 item-import 문서를 현재 MMKV 데이터 뒤에 병합한다. 전체 복원이 아니라 append 방식이다. */
 export const importItemImportDocument = async (document: ItemImportDocument): Promise<void> => {
-  const remappedItems = remapImportedItems(document.payload.knitItems);
+  const existingItems = getStoredItems();
+  const remappedItems = remapImportedItems(document.payload.knitItems, existingItems);
+
+  // import 묶음 자체뿐 아니라, 기존 데이터와 합쳐졌을 때도 참조/ID 무결성이 유지되는지 마지막으로 확인한다.
+  if (!hasValidItemSemantics([...existingItems, ...remappedItems])) {
+    throw new Error('프로젝트 불러오기 후 데이터 연결 구조가 올바르지 않습니다.');
+  }
+
   appendImportedItems(remappedItems);
   ensureDataMigration();
 };

--- a/src/storage/backup.ts
+++ b/src/storage/backup.ts
@@ -771,10 +771,12 @@ const isItemArray = (value: unknown, dataVersion: number): value is Item[] => {
   return allItemsAreValid && hasValidItemSemantics(value);
 };
 
+// item-import는 템플릿 문서이므로 저장 시각 같은 앱 로컬 전용 필드는 받지 않는다.
 const hasForbiddenItemImportProjectFields = (value: Record<string, unknown>): boolean => {
   return 'updatedAt' in value;
 };
 
+// 실행 중 상태나 기록성 필드는 import 대상이 아니므로 문서에 섞여 있으면 거부한다.
 const hasForbiddenItemImportCounterFields = (value: Record<string, unknown>): boolean => {
   return 'elapsedTime' in value
     || 'timerIsActive' in value
@@ -783,12 +785,15 @@ const hasForbiddenItemImportCounterFields = (value: Record<string, unknown>): bo
     || 'updatedAt' in value;
 };
 
+// project는 구조가 단순하므로 참조 정보(counterIds)와 info만 확인한다.
 const isItemImportProjectItem = (value: Record<string, unknown>): boolean => {
   return !hasForbiddenItemImportProjectFields(value)
     && isStringArray(value.counterIds)
     && isInfo(value.info);
 };
 
+// counter는 import 후 즉시 사용할 세팅값만 받는다.
+// 경과 시간/기록은 문서에서 제외하고, repeatRules 등 설정성 필드는 그대로 유지한다.
 const isItemImportCounterItem = (
   value: Record<string, unknown>,
   dataVersion: number
@@ -815,6 +820,7 @@ const isItemImportCounterItem = (
   return value.repeatRules.every((rule) => isRepeatRule(rule, dataVersion));
 };
 
+// item-import는 템플릿 ID를 허용하지만, 프로젝트-카운터 참조 무결성은 여기서 먼저 점검한다.
 const isItemImportArray = (value: unknown, dataVersion: number): value is ItemImportItem[] => {
   if (!Array.isArray(value)) {
     return false;
@@ -839,6 +845,7 @@ const isItemImportArray = (value: unknown, dataVersion: number): value is ItemIm
   return allItemsAreValid && hasValidReferenceSemantics(value as ItemReferenceShape[]);
 };
 
+/** item-import payload는 knitItems만 포함하며, 검증 실패 시 사용자에게 바로 보여줄 에러를 던진다. */
 const assertValidItemImportPayload = (
   value: unknown,
   dataVersion: number
@@ -1075,10 +1082,15 @@ export const parseBackupDocument = (json: string): BackupDocument => {
   };
 };
 
+/**
+ * 템플릿 문서의 ID를 현재 기기 전용 ID로 재발급하고,
+ * import 대상에 없는 실행 상태 필드는 앱 기본값으로 보정한다.
+ */
 const remapImportedItems = (items: ItemImportItem[]): Item[] => {
   const baseTimestamp = Date.now();
   const oldIdToNewId = new Map<string, string>();
 
+  // project/counter 모두 먼저 새 ID를 배정해 둬야 이후 참조 치환(counterIds/parentProjectId)이 단순해진다.
   items.forEach((item, index) => {
     const nextTimestamp = baseTimestamp + index;
     const prefix = item.type === 'project' ? 'proj' : 'counter';
@@ -1098,6 +1110,7 @@ const remapImportedItems = (items: ItemImportItem[]): Item[] => {
         id: mappedId,
         type: 'project',
         title: item.title,
+        // 프로젝트는 자식 카운터 순서를 유지한 채 새 counter ID 목록으로 치환한다.
         counterIds: item.counterIds.map((counterId) => {
           const mappedCounterId = oldIdToNewId.get(counterId);
 
@@ -1126,6 +1139,7 @@ const remapImportedItems = (items: ItemImportItem[]): Item[] => {
       title: item.title,
       count: item.count,
       targetCount: item.targetCount,
+      // item-import 문서는 "세팅된 프로젝트"만 전달하므로 실행 상태는 항상 초기화한다.
       elapsedTime: 0,
       timerIsActive: false,
       timerIsPlaying: false,
@@ -1152,6 +1166,7 @@ const remapImportedItems = (items: ItemImportItem[]): Item[] => {
   return normalizedItems;
 };
 
+// 백업 import와 item-import가 공통으로 쓰는 "JSON 파일 선택 후 문자열 읽기" 단계.
 const pickJsonDocumentContents = async (): Promise<string | null> => {
   const result = await DocumentPicker.getDocumentAsync({
     type: 'application/json',
@@ -1169,6 +1184,7 @@ const pickJsonDocumentContents = async (): Promise<string | null> => {
   });
 };
 
+/** 프로젝트 불러오기 전용 문서를 파싱하고, 앱이 신뢰할 수 있는 최소 형식인지 검증한다. */
 export const parseItemImportDocument = (json: string): ItemImportDocument => {
   let parsed: unknown;
 
@@ -1211,6 +1227,7 @@ export const parseItemImportDocument = (json: string): ItemImportDocument => {
   };
 };
 
+/** 사용자가 고른 JSON 파일을 item-import 문서로 읽는다. 취소 시 null을 반환한다. */
 export const pickItemImportDocument = async (): Promise<ItemImportDocument | null> => {
   const contents = await pickJsonDocumentContents();
 
@@ -1221,10 +1238,12 @@ export const pickItemImportDocument = async (): Promise<ItemImportDocument | nul
   return parseItemImportDocument(contents);
 };
 
+/** 무료 맛보기 버튼이 사용하는 앱 내장 샘플 문서를 동일한 파서 경로로 읽는다. */
 export const getBundledItemImportDocument = (): ItemImportDocument => {
   return parseItemImportDocument(JSON.stringify(BUNDLED_ITEM_IMPORT_DOCUMENT));
 };
 
+/** 검증된 item-import 문서를 현재 MMKV 데이터 뒤에 병합한다. 전체 복원이 아니라 append 방식이다. */
 export const importItemImportDocument = async (document: ItemImportDocument): Promise<void> => {
   const remappedItems = remapImportedItems(document.payload.knitItems);
   appendImportedItems(remappedItems);

--- a/src/storage/backup.ts
+++ b/src/storage/backup.ts
@@ -1224,6 +1224,12 @@ export const parseItemImportDocument = (json: string): ItemImportDocument => {
     throw new Error('프로젝트 데이터 버전 정보가 올바르지 않습니다.');
   }
 
+  // item-import는 restoreBackupDocument처럼 문서 버전에 맞춘 전체 복원 경로를 타지 않으므로,
+  // 현재 앱이 모르는 "미래 버전" 문서는 안전하게 해석할 수 없다고 보고 여기서 거부한다.
+  if (parsed.dataVersion > CURRENT_DATA_VERSION) {
+    throw new Error('이 버전의 앱에서는 더 최신 프로젝트 불러오기 파일을 지원하지 않습니다.');
+  }
+
   return {
     formatVersion: BACKUP_FORMAT_VERSION,
     appId: APP_ID,

--- a/src/storage/backup.ts
+++ b/src/storage/backup.ts
@@ -1,8 +1,17 @@
 import * as DocumentPicker from 'expo-document-picker';
 import * as FileSystem from 'expo-file-system';
 import * as Sharing from 'expo-sharing';
-import type { Item, SortCriteria, SortOrder } from './types';
-import { getStoredItems } from './storage';
+import type {
+  Item,
+  ItemImportCounter,
+  ItemImportDocument,
+  ItemImportItem,
+  ItemImportPayload,
+  ItemImportSummary,
+  SortCriteria,
+  SortOrder,
+} from './types';
+import { appendImportedItems, getStoredItems } from './storage';
 import {
   getAutoPlayElapsedTimeSetting,
   getSelectedColorThemeSetting,
@@ -53,6 +62,7 @@ import {
 
 const APP_ID = 'awesome-knit-row-counter';
 const BACKUP_FORMAT_VERSION = 1;
+const ITEM_IMPORT_TYPE = 'item-import';
 const MAX_COUNTER_VALUE = 9999;
 const MAX_ELAPSED_TIME_SECONDS = 35999999;
 const MAX_TITLE_LENGTH = 15;
@@ -71,6 +81,7 @@ const KEY_DISMISSED_ONESTORE_APP_VERSION = 'updatePrompt.dismissedOnestoreAppVer
 const BACKUP_DIRECTORY_NAME = 'backups';
 const BACKUP_FILE_PREFIX = 'awesome-knit-row-counter-backup';
 const BACKUP_FILE_EXTENSION = '.json';
+const BUNDLED_ITEM_IMPORT_DOCUMENT = require('../assets/item-imports/awesome-knit-item-import-sample.json') as ItemImportDocument;
 
 type Nullable<T> = T | null;
 
@@ -137,6 +148,14 @@ const isStringArray = (value: unknown): value is string[] => {
 /** 앱이 생성하는 아이템 ID 형식(proj_/counter_ + timestamp)인지 확인한다. */
 const isGeneratedItemId = (value: unknown): value is string => {
   return typeof value === 'string' && /^(proj|counter)_\d+$/.test(value);
+};
+
+/** item-import 문서에서 임시 템플릿 ID를 포함한 문자열 ID를 허용한다. */
+const isImportItemId = (value: unknown): value is string => {
+  return typeof value === 'string'
+    && isTrimmedString(value)
+    && value.length > 0
+    && getCharacterLength(value) <= MAX_LONG_TEXT_LENGTH;
 };
 
 /** 사용자 지정 음성 명령어 3칸 입력 구조인지 확인한다. */
@@ -544,6 +563,85 @@ const hasUniqueIds = (items: Item[]): boolean => {
   return true;
 };
 
+type ItemReferenceShape = {
+  id: string;
+  type: 'project' | 'counter';
+  title: string;
+  counterIds?: string[];
+  parentProjectId?: string | null;
+};
+
+const hasUniqueReferenceIds = <T extends Pick<ItemReferenceShape, 'id'>>(
+  items: T[]
+): boolean => {
+  const ids = new Set<string>();
+
+  for (const item of items) {
+    if (ids.has(item.id)) {
+      return false;
+    }
+
+    ids.add(item.id);
+  }
+
+  return true;
+};
+
+const hasValidReferenceTitles = <T extends Pick<ItemReferenceShape, 'title'>>(
+  items: T[]
+): boolean => {
+  return items.every((item) => isTrimmedNonEmptyStringWithinLength(item.title, MAX_TITLE_LENGTH));
+};
+
+const hasValidReferenceProjectCounterReferences = <T extends ItemReferenceShape>(
+  items: T[]
+): boolean => {
+  const projects = items.filter((item) => item.type === 'project');
+  const counters = items.filter((item) => item.type === 'counter');
+  const projectMap = new Map(projects.map((project) => [project.id, project]));
+  const counterMap = new Map(counters.map((counter) => [counter.id, counter]));
+
+  for (const project of projects) {
+    const counterIdSet = new Set<string>();
+
+    for (const counterId of project.counterIds ?? []) {
+      if (counterIdSet.has(counterId)) {
+        return false;
+      }
+
+      counterIdSet.add(counterId);
+
+      const counter = counterMap.get(counterId);
+      if (!counter || counter.parentProjectId !== project.id) {
+        return false;
+      }
+    }
+  }
+
+  for (const counter of counters) {
+    if (counter.parentProjectId == null) {
+      continue;
+    }
+
+    const parentProject = projectMap.get(counter.parentProjectId);
+    if (!parentProject) {
+      return false;
+    }
+
+    if (!(parentProject.counterIds ?? []).includes(counter.id)) {
+      return false;
+    }
+  }
+
+  return true;
+};
+
+const hasValidReferenceSemantics = <T extends ItemReferenceShape>(items: T[]): boolean => {
+  return hasUniqueReferenceIds(items)
+    && hasValidReferenceTitles(items)
+    && hasValidReferenceProjectCounterReferences(items);
+};
+
 // 제목 중복은 앱에서 경고 후 허용할 수 있으므로, 백업 검증에서는 길이/trim만 강제한다.
 // 대신 복원 후 구조가 깨지지 않도록 프로젝트-카운터 참조 무결성은 엄격하게 본다.
 const hasValidTitleConstraints = (items: Item[]): boolean => {
@@ -671,6 +769,87 @@ const isItemArray = (value: unknown, dataVersion: number): value is Item[] => {
   });
 
   return allItemsAreValid && hasValidItemSemantics(value);
+};
+
+const hasForbiddenItemImportProjectFields = (value: Record<string, unknown>): boolean => {
+  return 'updatedAt' in value;
+};
+
+const hasForbiddenItemImportCounterFields = (value: Record<string, unknown>): boolean => {
+  return 'elapsedTime' in value
+    || 'timerIsActive' in value
+    || 'timerIsPlaying' in value
+    || 'sectionRecords' in value
+    || 'updatedAt' in value;
+};
+
+const isItemImportProjectItem = (value: Record<string, unknown>): boolean => {
+  return !hasForbiddenItemImportProjectFields(value)
+    && isStringArray(value.counterIds)
+    && isInfo(value.info);
+};
+
+const isItemImportCounterItem = (
+  value: Record<string, unknown>,
+  dataVersion: number
+): value is ItemImportCounter => {
+  if (
+    hasForbiddenItemImportCounterFields(value)
+    || !isCounterValue(value.count)
+    || !isCounterValue(value.targetCount)
+    || !(value.parentProjectId === undefined || value.parentProjectId === null || typeof value.parentProjectId === 'string')
+    || !isInfo(value.info)
+    || !isOptionalWay(value.way)
+    || !isCounterValue(value.subCount)
+    || !isNonNegativeInteger(value.subRule)
+    || typeof value.subRuleIsActive !== 'boolean'
+    || typeof value.subModalIsOpen !== 'boolean'
+    || typeof value.mascotIsActive !== 'boolean'
+    || typeof value.wayIsChange !== 'boolean'
+    || !Array.isArray(value.repeatRules)
+    || typeof value.sectionModalIsOpen !== 'boolean'
+  ) {
+    return false;
+  }
+
+  return value.repeatRules.every((rule) => isRepeatRule(rule, dataVersion));
+};
+
+const isItemImportArray = (value: unknown, dataVersion: number): value is ItemImportItem[] => {
+  if (!Array.isArray(value)) {
+    return false;
+  }
+
+  const allItemsAreValid = value.every((item) => {
+    if (!isRecord(item) || !isImportItemId(item.id) || typeof item.title !== 'string') {
+      return false;
+    }
+
+    if (item.type === 'project') {
+      return isItemImportProjectItem(item);
+    }
+
+    if (item.type === 'counter') {
+      return isItemImportCounterItem(item, dataVersion);
+    }
+
+    return false;
+  });
+
+  return allItemsAreValid && hasValidReferenceSemantics(value as ItemReferenceShape[]);
+};
+
+const assertValidItemImportPayload = (
+  value: unknown,
+  dataVersion: number
+): ItemImportPayload => {
+  if (!isRecord(value) || !isItemImportArray(value.knitItems, dataVersion)) {
+    throw new Error('프로젝트 데이터 형식이 올바르지 않습니다.');
+  }
+
+  return {
+    knitItems: value.knitItems,
+  };
 };
 
 /** settings payload 전체가 앱이 저장하는 설정 구조와 일치하는지 검증한다. */
@@ -896,6 +1075,162 @@ export const parseBackupDocument = (json: string): BackupDocument => {
   };
 };
 
+const remapImportedItems = (items: ItemImportItem[]): Item[] => {
+  const baseTimestamp = Date.now();
+  const oldIdToNewId = new Map<string, string>();
+
+  items.forEach((item, index) => {
+    const nextTimestamp = baseTimestamp + index;
+    const prefix = item.type === 'project' ? 'proj' : 'counter';
+    oldIdToNewId.set(item.id, `${prefix}_${nextTimestamp}`);
+  });
+
+  const normalizedItems = items.map((item, index): Item => {
+    const mappedId = oldIdToNewId.get(item.id);
+    const nextTimestamp = baseTimestamp + index;
+
+    if (!mappedId) {
+      throw new Error('프로젝트 불러오기 ID를 생성하지 못했습니다.');
+    }
+
+    if (item.type === 'project') {
+      return {
+        id: mappedId,
+        type: 'project',
+        title: item.title,
+        counterIds: item.counterIds.map((counterId) => {
+          const mappedCounterId = oldIdToNewId.get(counterId);
+
+          if (!mappedCounterId) {
+            throw new Error('프로젝트-카운터 연결 정보가 올바르지 않습니다.');
+          }
+
+          return mappedCounterId;
+        }),
+        info: item.info ? { ...item.info } : undefined,
+        updatedAt: nextTimestamp,
+      };
+    }
+
+    const mappedParentProjectId = item.parentProjectId == null
+      ? null
+      : oldIdToNewId.get(item.parentProjectId);
+
+    if (item.parentProjectId != null && !mappedParentProjectId) {
+      throw new Error('카운터의 부모 프로젝트 연결 정보가 올바르지 않습니다.');
+    }
+
+    return {
+      id: mappedId,
+      type: 'counter',
+      title: item.title,
+      count: item.count,
+      targetCount: item.targetCount,
+      elapsedTime: 0,
+      timerIsActive: false,
+      timerIsPlaying: false,
+      parentProjectId: mappedParentProjectId,
+      info: item.info ? { ...item.info } : undefined,
+      way: item.way,
+      subCount: item.subCount,
+      subRule: item.subRule,
+      subRuleIsActive: item.subRuleIsActive,
+      subModalIsOpen: item.subModalIsOpen,
+      mascotIsActive: item.mascotIsActive,
+      wayIsChange: item.wayIsChange,
+      repeatRules: item.repeatRules.map((rule) => ({ ...rule })),
+      sectionRecords: [],
+      sectionModalIsOpen: item.sectionModalIsOpen,
+      updatedAt: nextTimestamp,
+    };
+  });
+
+  if (!hasValidItemSemantics(normalizedItems)) {
+    throw new Error('프로젝트 불러오기 데이터 연결 구조가 올바르지 않습니다.');
+  }
+
+  return normalizedItems;
+};
+
+const pickJsonDocumentContents = async (): Promise<string | null> => {
+  const result = await DocumentPicker.getDocumentAsync({
+    type: 'application/json',
+    copyToCacheDirectory: true,
+    multiple: false,
+  });
+
+  if (result.canceled || !result.assets?.[0]) {
+    return null;
+  }
+
+  const [asset] = result.assets;
+  return FileSystem.readAsStringAsync(asset.uri, {
+    encoding: FileSystem.EncodingType.UTF8,
+  });
+};
+
+export const parseItemImportDocument = (json: string): ItemImportDocument => {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    throw new Error('프로젝트 불러오기 파일을 읽지 못했습니다. JSON 형식을 확인해 주세요.');
+  }
+
+  if (!isRecord(parsed)) {
+    throw new Error('프로젝트 불러오기 파일 형식이 올바르지 않습니다.');
+  }
+
+  if (parsed.formatVersion !== BACKUP_FORMAT_VERSION) {
+    throw new Error('지원하지 않는 프로젝트 불러오기 파일 버전입니다.');
+  }
+
+  if (parsed.appId !== APP_ID) {
+    throw new Error('이 앱에서 생성한 프로젝트 불러오기 파일이 아닙니다.');
+  }
+
+  if (parsed.importType !== ITEM_IMPORT_TYPE) {
+    throw new Error('프로젝트 불러오기 파일 타입이 올바르지 않습니다.');
+  }
+
+  if (
+    typeof parsed.dataVersion !== 'number'
+    || !Number.isFinite(parsed.dataVersion)
+    || parsed.dataVersion < 0
+  ) {
+    throw new Error('프로젝트 데이터 버전 정보가 올바르지 않습니다.');
+  }
+
+  return {
+    formatVersion: BACKUP_FORMAT_VERSION,
+    appId: APP_ID,
+    importType: ITEM_IMPORT_TYPE,
+    dataVersion: parsed.dataVersion,
+    payload: assertValidItemImportPayload(parsed.payload, parsed.dataVersion),
+  };
+};
+
+export const pickItemImportDocument = async (): Promise<ItemImportDocument | null> => {
+  const contents = await pickJsonDocumentContents();
+
+  if (!contents) {
+    return null;
+  }
+
+  return parseItemImportDocument(contents);
+};
+
+export const getBundledItemImportDocument = (): ItemImportDocument => {
+  return parseItemImportDocument(JSON.stringify(BUNDLED_ITEM_IMPORT_DOCUMENT));
+};
+
+export const importItemImportDocument = async (document: ItemImportDocument): Promise<void> => {
+  const remappedItems = remapImportedItems(document.payload.knitItems);
+  appendImportedItems(remappedItems);
+  ensureDataMigration();
+};
+
 /** 선택 문자열 값을 저장하고, 비어 있으면 해당 키를 제거한다. */
 const setOptionalStringValue = (key: string, value: Nullable<string>) => {
   if (typeof value === 'string' && value.length > 0) {
@@ -1001,20 +1336,11 @@ export const shareBackupFile = async (fileUri: string) => {
 
 /** 문서 선택기에서 JSON 백업 파일을 고른 뒤 파싱된 문서를 반환한다. */
 export const pickBackupDocument = async (): Promise<BackupDocument | null> => {
-  const result = await DocumentPicker.getDocumentAsync({
-    type: 'application/json',
-    copyToCacheDirectory: true,
-    multiple: false,
-  });
+  const contents = await pickJsonDocumentContents();
 
-  if (result.canceled || !result.assets?.[0]) {
+  if (!contents) {
     return null;
   }
-
-  const [asset] = result.assets;
-  const contents = await FileSystem.readAsStringAsync(asset.uri, {
-    encoding: FileSystem.EncodingType.UTF8,
-  });
 
   return parseBackupDocument(contents);
 };
@@ -1031,6 +1357,24 @@ export const getBackupSummary = (document: BackupDocument): BackupSummary => {
 
   return {
     exportedAtLabel: new Date(document.exportedAt).toLocaleString('ko-KR'),
+    totalItems,
+    projectCount,
+    counterCount,
+  };
+};
+
+export const getItemImportSummary = (
+  document: ItemImportDocument
+): ItemImportSummary => {
+  const totalItems = document.payload.knitItems.length;
+  const projectCount = document.payload.knitItems.filter(
+    (item) => item.type === 'project'
+  ).length;
+  const counterCount = document.payload.knitItems.filter(
+    (item) => item.type === 'counter'
+  ).length;
+
+  return {
     totalItems,
     projectCount,
     counterCount,

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -31,6 +31,19 @@ const setStoredItems = (items: Item[]) => {
 };
 
 /**
+ * 여러 항목을 한 번에 뒤에 추가합니다.
+ * @param newItems 추가할 Item 배열
+ */
+export const appendImportedItems = (newItems: Item[]) => {
+  if (newItems.length === 0) {
+    return;
+  }
+
+  const existing = getStoredItems();
+  setStoredItems([...existing, ...newItems]);
+};
+
+/**
  * 새로운 항목을 추가합니다.
  * @param newItem 추가할 새로운 Item
  */

--- a/src/storage/storage.ts
+++ b/src/storage/storage.ts
@@ -32,6 +32,8 @@ const setStoredItems = (items: Item[]) => {
 
 /**
  * 여러 항목을 한 번에 뒤에 추가합니다.
+ * 프로젝트 불러오기는 기존 데이터를 유지한 채 append 해야 하므로
+ * addItem 반복 대신 한 번에 저장하는 전용 경로를 둡니다.
  * @param newItems 추가할 Item 배열
  */
 export const appendImportedItems = (newItems: Item[]) => {

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -112,3 +112,32 @@ export type Project = {
 
 // 모든 아이템의 공통 타입 (프로젝트 또는 카운터)
 export type Item = Project | Counter;
+
+// ===== 프로젝트 불러오기 타입 =====
+
+export type ItemImportProject = Omit<Project, 'updatedAt'>;
+
+export type ItemImportCounter = Omit<
+  Counter,
+  'elapsedTime' | 'timerIsActive' | 'timerIsPlaying' | 'sectionRecords' | 'updatedAt'
+>;
+
+export type ItemImportItem = ItemImportProject | ItemImportCounter;
+
+export type ItemImportPayload = {
+  knitItems: ItemImportItem[];
+};
+
+export type ItemImportDocument = {
+  formatVersion: 1;
+  appId: 'awesome-knit-row-counter';
+  importType: 'item-import';
+  dataVersion: number;
+  payload: ItemImportPayload;
+};
+
+export type ItemImportSummary = {
+  totalItems: number;
+  projectCount: number;
+  counterCount: number;
+};

--- a/src/storage/types.ts
+++ b/src/storage/types.ts
@@ -115,8 +115,11 @@ export type Item = Project | Counter;
 
 // ===== 프로젝트 불러오기 타입 =====
 
+// item-import 문서는 앱 내부 저장 시각(updatedAt)을 포함하지 않는다.
 export type ItemImportProject = Omit<Project, 'updatedAt'>;
 
+// item-import 문서는 "세팅된 프로젝트"만 전달하므로,
+// 실행 중 상태(타이머/경과시간/활동기록)는 받지 않고 import 시 기본값으로 채운다.
 export type ItemImportCounter = Omit<
   Counter,
   'elapsedTime' | 'timerIsActive' | 'timerIsPlaying' | 'sectionRecords' | 'updatedAt'
@@ -124,10 +127,12 @@ export type ItemImportCounter = Omit<
 
 export type ItemImportItem = ItemImportProject | ItemImportCounter;
 
+// item-import는 설정/업데이트 프롬프트 없이 knitItems만 전달한다.
 export type ItemImportPayload = {
   knitItems: ItemImportItem[];
 };
 
+// 도안/프로젝트 배포용 JSON의 루트 문서 형식.
 export type ItemImportDocument = {
   formatVersion: 1;
   appId: 'awesome-knit-row-counter';
@@ -136,6 +141,7 @@ export type ItemImportDocument = {
   payload: ItemImportPayload;
 };
 
+// 확인 모달에 보여줄 최소 요약 정보.
 export type ItemImportSummary = {
   totalItems: number;
   projectCount: number;

--- a/src/utils/itemIdUtils.ts
+++ b/src/utils/itemIdUtils.ts
@@ -1,0 +1,21 @@
+export type ItemIdPrefix = 'proj' | 'counter';
+
+/**
+ * 현재 예약된 ID 집합을 기준으로, 주어진 seed 이상에서 충돌하지 않는 다음 item ID를 만든다.
+ * 기존 정책인 `prefix_timestamp` 형식은 유지하고, 충돌 시 숫자만 1씩 증가시켜 회피한다.
+ */
+export const createUniqueItemId = (
+  prefix: ItemIdPrefix,
+  reservedIds: Set<string>,
+  seed: number = Date.now()
+): string => {
+  let nextSeed = Math.max(0, Math.trunc(seed));
+
+  while (reservedIds.has(`${prefix}_${nextSeed}`)) {
+    nextSeed += 1;
+  }
+
+  const generatedId = `${prefix}_${nextSeed}`;
+  reservedIds.add(generatedId);
+  return generatedId;
+};

--- a/src/utils/replicationUtils.ts
+++ b/src/utils/replicationUtils.ts
@@ -1,4 +1,5 @@
 import { Counter, Item, Project } from '@storage/types';
+import { createUniqueItemId } from './itemIdUtils';
 
 const TITLE_MAX_LENGTH = 15;
 
@@ -122,7 +123,8 @@ export function buildReplicatedProjectBundle(
   allItems: Item[]
 ): ReplicatedProjectBundle {
   const baseTs = Date.now();
-  const newProjectId = `proj_${baseTs}`;
+  const reservedIds = new Set(allItems.map((item) => item.id));
+  const newProjectId = createUniqueItemId('proj', reservedIds, baseTs);
 
   const resolved: Counter[] = [];
   for (const oldId of source.counterIds) {
@@ -145,7 +147,7 @@ export function buildReplicatedProjectBundle(
   let offset = 0;
   for (const old of byCreatedAsc) {
     offset += 1;
-    oldIdToNewId.set(old.id, `counter_${baseTs + offset}`);
+    oldIdToNewId.set(old.id, createUniqueItemId('counter', reservedIds, baseTs + offset));
   }
 
   const counters: Counter[] = [];


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #204 


## 🛠 작업 내용
- 협업자와 논의 후 기능명, 맛보기 도안 제공, 설명즐굴과 설명 툴팁 내용을 확정하여 구현했습니다.

<img width="756" height="1485" alt="image" src="https://github.com/user-attachments/assets/96a0eb02-3bac-4124-9b7d-e53466d4bad0" />

- 앱 설정을 제외하고 아이템들만 불러올 수 있는 유료 기능 프로젝트 불러오기입니다.
- 알림 단, 목표 단수, info 가 미리 작성되어 있는 카운터를 불러와 사용할 수 있습니다.

- 기존 backup파일에 덧붙여 json파일 유효성 검사 로직을 추가했습니다.
- 유료 기능으로 프로젝트 불러오기 버튼을 추가하고, 앱에 프로젝트를 불러올 수 있도록 했습니다
  - 아이템의 id는 사용자가 불러올 때 규칙에 맞춰서 생성할 수 있도록 했습니다.
  - 프로젝트와 카운터의 부모자식 참조가 깨지지 않도록 했습니다.
- 버튼을 추가하여 앱 내에서 기본 도안 2개를 제공해줄 수 있도록 했습니다.

- 기존 데이터 불러오기 기능과의 혼동을 방지하고자, '데이터 불러오기/내보내기'는 '**전체** 데이터 불러오기/내보내기'로 기능명을 수정했습니다.
- 아이템 생성, 불러오기에서 중복 id를 방어하는 util을 생성해 적용했습니다.

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->
추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)
차후 앱 제공 도안 json파일은 완성이 필요합니다. 현재 미완성 도안으로 업로드 해두었습니다.

- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 시스템 폰트 사이즈, 화면 크기 변화에 대응하는 걸 확인했습니다.
- [x] 동료 작업자에게 수정 사항을 공유했습니다. 