### PR TITLE
feat: 사용자 커스텀 음성 인식 초기화 명령어

### DIFF
--- a/src/components/settings/SettingsItemImport.tsx
+++ b/src/components/settings/SettingsItemImport.tsx
@@ -222,12 +222,12 @@ const SettingsItemImport: React.FC<SettingsItemImportProps> = () => {
           {!premiumUnlocked ? (
             <>
               <View
-                className="pointer-events-none absolute -inset-2 z-[5] rounded-2xl bg-mediumgray overflow-hidden"
+                className="pointer-events-none absolute inset-y-0 -inset-x-2 z-[5] rounded-2xl overflow-hidden bg-mediumgray"
                 style={PREMIUM_OVERLAY_STYLE}
               />
               <TouchableOpacity
                 activeOpacity={1}
-                className="absolute -inset-2 z-[10] rounded-2xl"
+                className="absolute inset-y-0 -inset-x-2 z-[10] rounded-2xl"
                 onPress={() => navigation.navigate('PremiumPurchase')}
                 accessibilityRole="button"
                 accessibilityLabel="프로젝트 불러오기"

--- a/src/components/settings/SettingsVoiceCommands.tsx
+++ b/src/components/settings/SettingsVoiceCommands.tsx
@@ -22,8 +22,10 @@ import SettingsSectionHeader from './SettingsSectionHeader';
 type VoiceCommandGroupKey =
   | 'mainDecrease'
   | 'mainIncrease'
+  | 'mainReset'
   | 'subDecrease'
-  | 'subIncrease';
+  | 'subIncrease'
+  | 'subReset';
 
 interface VoiceCommandRowConfig {
   key: VoiceCommandGroupKey;
@@ -35,11 +37,19 @@ interface VoiceCommandRowConfig {
 const DEFAULT_VOICE_COMMAND_SECTIONS = [
   {
     title: '본 카운터',
-    description: '연지(현지, 연기) / 곤지(군지, 건지)',
+    descriptions: [
+      '카운트 감소: 연지(현지, 연기)',
+      '카운트 증가: 곤지(군지, 건지)',
+      '초기화: 메인(매일, 매인)',
+    ],
   },
   {
     title: '보조 카운터',
-    description: '청실(청신, 창신) / 홍실(홍신, 동실)',
+    descriptions: [
+      '카운트 감소: 청실(청신, 창신)',
+      '카운트 증가: 홍실(홍신, 동실)',
+      '초기화: 서브',
+    ],
   },
 ] as const;
 
@@ -57,6 +67,12 @@ const VOICE_COMMAND_ROW_CONFIGS: VoiceCommandRowConfig[] = [
     placeholders: ['사과', '사와', '서과'],
   },
   {
+    key: 'mainReset',
+    sectionTitle: '본 카운터',
+    label: '초기화',
+    placeholders: ['콜라', '콜러', '콘라'],
+  },
+  {
     key: 'subDecrease',
     sectionTitle: '보조 카운터',
     label: '카운트 감소',
@@ -67,6 +83,12 @@ const VOICE_COMMAND_ROW_CONFIGS: VoiceCommandRowConfig[] = [
     sectionTitle: '보조 카운터',
     label: '카운트 증가',
     placeholders: ['제이', '체이', '데이'],
+  },
+  {
+    key: 'subReset',
+    sectionTitle: '보조 카운터',
+    label: '초기화',
+    placeholders: ['중독', '준독', '정독'],
   },
 ];
 
@@ -94,8 +116,10 @@ const SettingsVoiceCommands: React.FC = () => {
     useState<CustomVoiceCommandInputsSetting>({
       mainDecrease: ['', '', ''],
       mainIncrease: ['', '', ''],
+      mainReset: ['', '', ''],
       subDecrease: ['', '', ''],
       subIncrease: ['', '', ''],
+      subReset: ['', '', ''],
     });
   const [voiceCommandSettingsHydrated, setVoiceCommandSettingsHydrated] =
     useState(false);
@@ -275,12 +299,12 @@ const SettingsVoiceCommands: React.FC = () => {
                     textAlign="center"
                     fillWidth={false}
                     returnKeyType={
-                      config.key === 'subIncrease' && index === 2 ? 'done' : 'next'
+                      config.key === 'subReset' && index === 2 ? 'done' : 'next'
                     }
                     onSubmitEditing={() =>
                       handleVoiceCommandSubmitEditing(config.key, index)
                     }
-                    blurOnSubmit={config.key === 'subIncrease' && index === 2}
+                    blurOnSubmit={config.key === 'subReset' && index === 2}
                   />
                 );
               })}
@@ -318,9 +342,16 @@ const SettingsVoiceCommands: React.FC = () => {
               <Text className="text-base font-semibold text-black">
                 {section.title}
               </Text>
-              <Text className="pl-4 pt-1 text-base leading-6 text-black">
-                {section.description}
-              </Text>
+              <View className="pl-4 pt-1">
+                {section.descriptions.map((description) => (
+                  <Text
+                    key={`${section.title}-${description}`}
+                    className="text-base leading-6 text-black"
+                  >
+                    {description}
+                  </Text>
+                ))}
+              </View>
             </View>
           ))}
         </SettingsAccordion>

--- a/src/constants/voiceCommandKeywords.ts
+++ b/src/constants/voiceCommandKeywords.ts
@@ -7,9 +7,6 @@ export const DEFAULT_VOICE_COMMAND_KEYWORDS = {
   subtract: ['연지', '현지', '연기'],
   subAdd: ['홍실', '홍신', '동실', '통실', '봉실', '뽕실', '통신', '공실', '홍시', '화실'],
   subSubtract: ['청실', '청신', '창실', '정신', '정실'],
-} as const;
-
-export const VOICE_RESET_COMMAND_KEYWORDS = {
-  main: ['메인', '매일', '매인'],
-  sub: ['서브'],
+  mainReset: ['메인', '매일', '매인'],
+  subReset: ['서브'],
 } as const;

--- a/src/hooks/useVoiceCommands.ts
+++ b/src/hooks/useVoiceCommands.ts
@@ -3,7 +3,6 @@
 import { useEffect, useRef } from 'react';
 import { AppState, Platform } from 'react-native';
 import { ExpoSpeechRecognitionModule } from 'expo-speech-recognition';
-import { VOICE_RESET_COMMAND_KEYWORDS } from '@constants/voiceCommandKeywords';
 import type { EffectiveVoiceCommandSetting } from '@storage/settings';
 
 const LOCALE = 'ko-KR';
@@ -40,7 +39,12 @@ const OFFLINE_MODEL_REQUIRED_MESSAGE =
 
 type VoiceCommandKeywordConfig = Pick<
   EffectiveVoiceCommandSetting,
-  'addKeywords' | 'subtractKeywords' | 'subAddKeywords' | 'subSubtractKeywords'
+  | 'addKeywords'
+  | 'subtractKeywords'
+  | 'subAddKeywords'
+  | 'subSubtractKeywords'
+  | 'mainResetKeywords'
+  | 'subResetKeywords'
 >;
 type VoiceCommandAction =
   | 'add'
@@ -268,8 +272,8 @@ export function useVoiceCommands(
       subtract: new Set(keywordConfig.subtractKeywords),
       subAdd: new Set(keywordConfig.subAddKeywords),
       subSubtract: new Set(keywordConfig.subSubtractKeywords),
-      mainReset: new Set(VOICE_RESET_COMMAND_KEYWORDS.main),
-      subReset: new Set(VOICE_RESET_COMMAND_KEYWORDS.sub),
+      mainReset: new Set(keywordConfig.mainResetKeywords),
+      subReset: new Set(keywordConfig.subResetKeywords),
     };
 
     // recognition session의 로컬 런타임 상태.
@@ -598,8 +602,8 @@ export function useVoiceCommands(
             ...keywordConfig.subtractKeywords,
             ...keywordConfig.subAddKeywords,
             ...keywordConfig.subSubtractKeywords,
-            ...VOICE_RESET_COMMAND_KEYWORDS.main,
-            ...VOICE_RESET_COMMAND_KEYWORDS.sub,
+            ...keywordConfig.mainResetKeywords,
+            ...keywordConfig.subResetKeywords,
           ],
           androidIntentOptions: {
             EXTRA_LANGUAGE_MODEL: 'web_search',
@@ -806,5 +810,7 @@ export function useVoiceCommands(
     keywordConfig.subtractKeywords,
     keywordConfig.subAddKeywords,
     keywordConfig.subSubtractKeywords,
+    keywordConfig.mainResetKeywords,
+    keywordConfig.subResetKeywords,
   ]);
 }

--- a/src/storage/settings.ts
+++ b/src/storage/settings.ts
@@ -53,8 +53,10 @@ export type ColorThemeSetting =
 export interface CustomVoiceCommandInputsSetting {
   mainDecrease: [string, string, string];
   mainIncrease: [string, string, string];
+  mainReset: [string, string, string];
   subDecrease: [string, string, string];
   subIncrease: [string, string, string];
+  subReset: [string, string, string];
 }
 
 export interface EffectiveVoiceCommandSetting {
@@ -64,17 +66,23 @@ export interface EffectiveVoiceCommandSetting {
   subtractKeywords: string[];
   subAddKeywords: string[];
   subSubtractKeywords: string[];
+  mainResetKeywords: string[];
+  subResetKeywords: string[];
   addHint: string;
   subtractHint: string;
   subAddHint: string;
   subSubtractHint: string;
+  mainResetHint: string;
+  subResetHint: string;
 }
 
 const DEFAULT_CUSTOM_VOICE_COMMAND_INPUTS: CustomVoiceCommandInputsSetting = {
   mainDecrease: ['', '', ''],
   mainIncrease: ['', '', ''],
+  mainReset: ['', '', ''],
   subDecrease: ['', '', ''],
   subIncrease: ['', '', ''],
+  subReset: ['', '', ''],
 };
 const STORED_CUSTOM_VOICE_COMMAND_MAX_LENGTH = 2;
 
@@ -126,8 +134,10 @@ const sanitizeStoredCustomVoiceCommandInputs = (
   return {
     mainDecrease: sanitizeStoredVoiceCommandTuple(value.mainDecrease),
     mainIncrease: sanitizeStoredVoiceCommandTuple(value.mainIncrease),
+    mainReset: sanitizeStoredVoiceCommandTuple(value.mainReset),
     subDecrease: sanitizeStoredVoiceCommandTuple(value.subDecrease),
     subIncrease: sanitizeStoredVoiceCommandTuple(value.subIncrease),
+    subReset: sanitizeStoredVoiceCommandTuple(value.subReset),
   };
 };
 
@@ -147,12 +157,18 @@ const normalizeCustomVoiceCommandInputs = (
     mainIncrease: isThreeStringTuple(candidate.mainIncrease)
       ? sanitizeStoredVoiceCommandTuple(candidate.mainIncrease)
       : DEFAULT_CUSTOM_VOICE_COMMAND_INPUTS.mainIncrease,
+    mainReset: isThreeStringTuple(candidate.mainReset)
+      ? sanitizeStoredVoiceCommandTuple(candidate.mainReset)
+      : DEFAULT_CUSTOM_VOICE_COMMAND_INPUTS.mainReset,
     subDecrease: isThreeStringTuple(candidate.subDecrease)
       ? sanitizeStoredVoiceCommandTuple(candidate.subDecrease)
       : DEFAULT_CUSTOM_VOICE_COMMAND_INPUTS.subDecrease,
     subIncrease: isThreeStringTuple(candidate.subIncrease)
       ? sanitizeStoredVoiceCommandTuple(candidate.subIncrease)
       : DEFAULT_CUSTOM_VOICE_COMMAND_INPUTS.subIncrease,
+    subReset: isThreeStringTuple(candidate.subReset)
+      ? sanitizeStoredVoiceCommandTuple(candidate.subReset)
+      : DEFAULT_CUSTOM_VOICE_COMMAND_INPUTS.subReset,
   };
 };
 
@@ -459,6 +475,8 @@ export const getEffectiveVoiceCommandSetting = (): EffectiveVoiceCommandSetting 
     const subtractKeywords = normalizeVoiceCommandKeywordList(customInputs.mainDecrease);
     const subAddKeywords = normalizeVoiceCommandKeywordList(customInputs.subIncrease);
     const subSubtractKeywords = normalizeVoiceCommandKeywordList(customInputs.subDecrease);
+    const mainResetKeywords = normalizeVoiceCommandKeywordList(customInputs.mainReset);
+    const subResetKeywords = normalizeVoiceCommandKeywordList(customInputs.subReset);
 
     return {
       mode,
@@ -467,10 +485,14 @@ export const getEffectiveVoiceCommandSetting = (): EffectiveVoiceCommandSetting 
       subtractKeywords,
       subAddKeywords,
       subSubtractKeywords,
+      mainResetKeywords,
+      subResetKeywords,
       addHint: customInputs.mainIncrease[0] ?? '',
       subtractHint: customInputs.mainDecrease[0] ?? '',
       subAddHint: customInputs.subIncrease[0] ?? '',
       subSubtractHint: customInputs.subDecrease[0] ?? '',
+      mainResetHint: customInputs.mainReset[0] ?? '',
+      subResetHint: customInputs.subReset[0] ?? '',
     };
   }
 
@@ -481,10 +503,14 @@ export const getEffectiveVoiceCommandSetting = (): EffectiveVoiceCommandSetting 
     subtractKeywords: [...DEFAULT_VOICE_COMMAND_KEYWORDS.subtract],
     subAddKeywords: [...DEFAULT_VOICE_COMMAND_KEYWORDS.subAdd],
     subSubtractKeywords: [...DEFAULT_VOICE_COMMAND_KEYWORDS.subSubtract],
+    mainResetKeywords: [...DEFAULT_VOICE_COMMAND_KEYWORDS.mainReset],
+    subResetKeywords: [...DEFAULT_VOICE_COMMAND_KEYWORDS.subReset],
     addHint: DEFAULT_VOICE_COMMAND_KEYWORDS.add[0],
     subtractHint: DEFAULT_VOICE_COMMAND_KEYWORDS.subtract[0],
     subAddHint: DEFAULT_VOICE_COMMAND_KEYWORDS.subAdd[0],
     subSubtractHint: DEFAULT_VOICE_COMMAND_KEYWORDS.subSubtract[0],
+    mainResetHint: DEFAULT_VOICE_COMMAND_KEYWORDS.mainReset[0],
+    subResetHint: DEFAULT_VOICE_COMMAND_KEYWORDS.subReset[0],
   };
 };
 


### PR DESCRIPTION
## 📌 Issue

<!-- 해결하려는 이슈 번호나 주제를 명확하게 적어주세요. -->

- 관련 이슈: close #227 


## 🛠 작업 내용

<p float="left">
<img width="48%" alt="image" src="https://github.com/user-attachments/assets/cb18b3d2-500a-4443-aed8-cae5e96f5231" />
<img width="48%" alt="image" src="https://github.com/user-attachments/assets/3f3e544a-92f9-4d0a-a1d1-c9ef83bbb225" />
</p>

- 기존 앱에서 지정한 '메인', '서브' 음성 명령어로 카운터를 초기화할 수 있었습니다.
- 프리미엄 유저는 명령어 지정 기능으로 초기화 명령어도 지정하여 사용할 수 있도록 했습니다.

## 🚀 기타 사항

<!-- 리뷰어가 추가적으로 알아야 할 사항이 있다면 기재해주세요. -->

추가적인 내용을 작성해주세요.(참고 자료, 협업 내용)

- [x] 코드 품질을 위한 자체 리뷰를 수행했습니다.
- [x] 불필요한 코드, 콘솔 로그, 주석 등을 제거했습니다.
- [x] 문서화가 필요한 경우 문서를 업데이트했습니다.
- [x] 시스템 폰트 사이즈, 화면 크기 변화에 대응하는 걸 확인했습니다.
- [x] 동료 작업자에게 수정 사항을 공유했습니다. 